### PR TITLE
Move ftap function and macro to helpers.core ns

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ This way, one can have schema validation and also always initialize the system c
 
 ### Debugging a flow
 
-You can use a `#nu/ftap` macro or the `state-flow.core/ftap` function to pretty print a State on a given moment during the flow in order to solve some problems easier.
+You can use a `#nu/ftap` macro or the `state-flow.helpers.core/ftap` function to pretty print a State on a given moment during the flow in order to solve some problems easier.
 
 E.g.:
 ```

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -1,7 +1,6 @@
 (ns state-flow.core
   (:refer-clojure :exclude [run!])
-  (:require [cljdev.core :as cljdev]
-            [cats.context :as ctx]
+  (:require [cats.context :as ctx]
             [cats.core :as m]
             [cats.data :as d]
             [cats.monad.exception :as e]
@@ -16,11 +15,6 @@
 
 (def sleep-time 10)
 (def times-to-try 100)
-
-(def ftap (partial m/fmap cljdev/tap))
-(defn functor-pprint
-  [form]
-  `(ftap ~form))
 
 (defn wrap-fn
   "Wraps a (possibly side-effecting) function to a state monad"

--- a/src/state_flow/helpers/core.clj
+++ b/src/state_flow/helpers/core.clj
@@ -1,5 +1,6 @@
 (ns state-flow.helpers.core
   (:require [cats.core :as m]
+            [cljdev.core :as cljdev]
             [com.stuartsierra.component :as component]
             [common-datomic.db :as ddb]
             [cats.monad.state :as state]
@@ -61,3 +62,8 @@
 (defn update-component
   [component-key update-fn]
   (system-swap (nu.state/swap #(update-in % [:system component-key] update-fn))))
+
+(def ftap (partial m/fmap cljdev/tap))
+(defn functor-pprint
+  [form]
+  `(ftap ~form))


### PR DESCRIPTION
# Summary

Moving `ftap` fn and macro to `helpers.core` namespace