### PR TITLE
Create defflow macro

### DIFF
--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -142,3 +142,16 @@
   "Returns all flows defined with `defflow`"
   [ns]
   (->> ns ns-interns vals (filter (comp ::test meta))))
+
+(defn run-test*
+  [v]
+  (let [{::keys [cleanup initialize]} (meta v)
+        initial-state (initialize)
+        [_ final-state :as result] (run @v initial-state)]
+    (cleanup final-state)
+    result))
+
+(defmacro run-test
+  "Runs test `test-name`defined with `deftest`"
+  [test-name]
+  `(run-test* (var ~test-name)))

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -50,6 +50,11 @@
     pop-meta
     (m/return ret#)))
 
+(defmacro defflow
+  [sym descr & flows]
+  `(def ~(vary-meta sym assoc ::test true)
+     (flow ~descr ~@flows)))
+
 (defn retry
   "Tries at most n times, returns a vector with true and first element that succeeded
   or false and result of the first try"
@@ -126,3 +131,8 @@
   "Transform a flow step into a state transition function"
   [flow]
   (fn [s] (state/exec flow s)))
+
+(defn ns->flows
+  "Returns all flows defined with `defflow`"
+  [ns]
+  (->> ns ns-interns vals (filter (comp ::test meta))))

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -41,6 +41,8 @@
     (m/return (description->string desc-list))))
 
 (defmacro flow
+  "Defines a flow"
+  {:style/indent :defn}
   [description & flows]
   `(m/do-let
     (push-meta ~description)

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -85,7 +85,7 @@
        (if (state/state? ~left-value)
          (probe-state full-desc# ~left-value ~right-value ~the-meta)
          (state/wrap-fn #(do (add-desc-and-meta ~fact-sexp full-desc# ~the-meta)
-                       ~left-value))))))
+                             ~left-value))))))
 
 (defn match-expr
   [desc value checker]

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -2,8 +2,9 @@
   (:require [cats.core :as m]
             [cats.data :as d]
             [matcher-combinators.matchers :as matchers]
+            [matcher-combinators.midje :refer [match]]
             [midje.sweet :refer :all]
-            [state-flow.core :as state-flow]
+            [state-flow.core :as state-flow :refer [defflow]]
             [cats.monad.state :as state]
             [state-flow.state :as sf.state]
             [com.stuartsierra.component :as component]))
@@ -136,3 +137,24 @@
 (facts "on as-step-fn"
   (let [increment-two-step (state-flow/as-step-fn (state/swap #(+ 2 %)))]
     (increment-two-step 1) => 3))
+
+
+(defflow flow-with-defflow
+  "Flow declaration here"
+  (println "Hello"))
+
+(facts "on `defflow`"
+  (fact "defines a flow"
+    (state/state? flow-with-defflow)
+    => truthy)
+  (fact "contains proper metadata"
+    (meta #'flow-with-defflow)
+    => (match {:column           number?
+               :file             string?
+               :line             number?
+               :name             'flow-with-defflow
+               ::state-flow/test true})))
+
+(facts "`ns->flows` only lists flows vars defined in namespace"
+  (state-flow/ns->flows 'state-flow.core-test)
+  => [#'flow-with-defflow])


### PR DESCRIPTION
The most important part of this macro is to add metadata to the var so we know it points to a flow. This is useful for writing a runner later (I'm planning on implementing a [lambdaisland/kaocha](/lambdaisland/kaocha) extension for it)