### PR TITLE
Add `assert` macro

### DIFF
--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -1,5 +1,6 @@
 (ns state-flow.core
-  (:refer-clojure :exclude [run!])
+  (:refer-clojure :exclude [run!]
+                  :rename {assert core-assert})
   (:require [cats.context :as ctx]
             [cats.core :as m]
             [cats.data :as d]
@@ -104,8 +105,8 @@
 
 (defn run
   [flow initial-state]
-  (assert (state/state? flow) "First argument must be a State Monad")
-  (assert (map? initial-state) "Initial state must be a map")
+  (core-assert (state/state? flow) "First argument must be a State Monad")
+  (core-assert (map? initial-state) "Initial state must be a map")
   (state/run flow initial-state))
 
 (defn run!
@@ -124,3 +125,16 @@
   "Transform a flow step into a state transition function"
   [flow]
   (fn [s] (state/exec flow s)))
+
+(defmacro assert
+  "Defines a step that, if it doesn't return a `truthy` value, throws an
+  exception."
+  {:style/indent 1}
+  [desc & body]
+  `(flow ~desc
+     [full-desc# (get-description)]
+     (let [ret# ~@body]
+       (or (and ret# (m/return ret#))
+           (throw (ex-info (str "Flow failed at assertion " full-desc#)
+                           {:reason ::assertion-failed
+                            :form '~body}))))))

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -8,7 +8,8 @@
             [cats.monad.state :as state]
             [state-flow.state :as sf.state]
             [com.stuartsierra.component :as component]
-            [cats.monad.exception :as e]))
+            [cats.monad.exception :as e]
+            [clojure.test :refer [is]]))
 
 (def increment-two
   (m/mlet [world (sf.state/get)]
@@ -161,4 +162,21 @@
               (state-flow/assert "some assertion that will pass"
                 (= 1 1))
               {:yo 1}))
-    => (match {:yo 1})))
+    => (match {:yo 1}))
+
+  (fact "works with clojure test"
+    (-> (state-flow/run
+          (state-flow/assert "some assertion that will not fail"
+            (is (= 1 1)))
+          {})
+        first
+        e/failure?)
+    => falsey
+
+    (-> (state-flow/run
+          (state-flow/assert "some assertion that will fail"
+            (is (= 1 2)))
+          {})
+        first
+        e/failure?)
+    => truthy))


### PR DESCRIPTION
Fixes nubank/state-flow#21

The `assert` macro receives a body and, if this body doesn't return a truthy value, it will throw an exception with the details to short circuit the flow.

TBH this is a hacky workaround. I'm experimenting with using an either monad instead of the exception monad and detect test errors differently, but I still don't have a working solution. I think it might be an opportunity to do what we discussed before and also return the test report when running it.