### PR TITLE
Improve support for clojure.test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.10.0]
+- Improved support for clojure test
+
 ## [1.9.1]
 - Add state related functions
 - Move wrap-fn to state namespace

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "1.9.1"
+(defproject nubank/state-flow "1.10.0"
 
   :description "Postman-like integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"

--- a/src/state_flow/cljtest.clj
+++ b/src/state_flow/cljtest.clj
@@ -1,6 +1,7 @@
 (ns state-flow.cljtest
   (:require [cats.core :as m]
             [clojure.test :as ctest :refer [is]]
+            [matcher-combinators.test]
             [state-flow.core :as core]
             [state-flow.state :as state]))
 

--- a/src/state_flow/cljtest.clj
+++ b/src/state_flow/cljtest.clj
@@ -1,5 +1,6 @@
 (ns state-flow.cljtest
-  (:require [clojure.test :as ctest :refer [is]]
+  (:require [cats.core :as m]
+            [clojure.test :as ctest :refer [is]]
             [state-flow.core :as core]
             [state-flow.state :as state]))
 
@@ -7,6 +8,10 @@
   [desc value checker]
   (let [test-name (symbol (clojure.string/replace desc " " "-"))]
     (list `ctest/testing desc (list `is (list 'match? checker value)))))
+
+(defmacro match+meta
+  [desc value checker meta]
+  (with-meta (match-expr desc value checker) meta))
 
 (defmacro match?
   "Builds a clojure.test assertion using matcher combinators"
@@ -16,9 +21,9 @@
        [full-desc# (core/get-description)]
        (if (state/state? ~value)
          (m/mlet [extracted-value# ~value]
-           (state/wrap-fn #(do (eval (with-meta (match-expr full-desc# extracted-value# ~checker) ~the-meta))
+           (state/wrap-fn #(do (match+meta full-desc# extracted-value# ~checker ~the-meta)
                                extracted-value#)))
-         (state/wrap-fn #(do (eval (with-meta (match-expr full-desc# ~value ~checker) ~the-meta))
+         (state/wrap-fn #(do (match+meta full-desc# ~value ~checker ~the-meta)
                              ~value))))))
 
 (defmacro deftest

--- a/src/state_flow/cljtest.clj
+++ b/src/state_flow/cljtest.clj
@@ -1,0 +1,59 @@
+(ns state-flow.cljtest
+  (:require [clojure.test :as ctest :refer [is]]
+            [state-flow.core :as core]
+            [state-flow.state :as state]))
+
+(defn match-expr
+  [desc value checker]
+  (let [test-name (symbol (clojure.string/replace desc " " "-"))]
+    (list `ctest/testing desc (list `is (list 'match? checker value)))))
+
+(defmacro match?
+  "Builds a clojure.test assertion using matcher combinators"
+  [desc value checker]
+  (let [the-meta (meta &form)]
+    `(core/flow ~desc
+       [full-desc# (core/get-description)]
+       (if (state/state? ~value)
+         (m/mlet [extracted-value# ~value]
+           (state/wrap-fn #(do (eval (with-meta (match-expr full-desc# extracted-value# ~checker) ~the-meta))
+                               extracted-value#)))
+         (state/wrap-fn #(do (eval (with-meta (match-expr full-desc# ~value ~checker) ~the-meta))
+                             ~value))))))
+
+(defmacro deftest
+  "Define a test to be run.
+
+  Receives optional parameters
+  `initializer-fn`, a function with no arguments that returns the initial state.
+  `cleanup-fn`, function receiving the final state to perform cleanup if necessary"
+  [sym
+   {:keys [initializer-fn
+           cleanup-fn
+           flow-runner]
+    :or   {initializer-fn `(constantly {})
+           cleanup-fn     `identity
+           flow-runner    `core/run!}}
+   & flows]
+  `(def ~(vary-meta sym merge {::test       true
+                               ::initialize initializer-fn
+                               ::cleanup    cleanup-fn})
+     (fn [initial-state#] (~flow-runner (core/flow ~(str sym) ~@flows) initial-state#))))
+
+(defn ns->tests
+  "Returns all flows defined with `deftest`"
+  [ns]
+  (->> ns ns-interns vals (filter (comp ::test meta))))
+
+(defn run-test*
+  [v]
+  (let [{::keys [cleanup initialize]} (meta v)
+        initial-state                 (initialize)
+        [_ final-state :as result]    (@v initial-state)]
+    (cleanup final-state)
+    result))
+
+(defmacro run-test
+  "Runs test `test-name`defined with `deftest`"
+  [test-name]
+  `(run-test* (var ~test-name)))

--- a/src/state_flow/cljtest.clj
+++ b/src/state_flow/cljtest.clj
@@ -35,4 +35,4 @@
                                forms
                                (cons {} forms))]
     `(ctest/deftest ~name
-       (core/run* ~parameters (core/flow (str ~name) ~@flows)))))
+       (core/run* ~parameters (core/flow ~(str name) ~@flows)))))

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -142,3 +142,16 @@
   "Returns all flows defined with `defflow`"
   [ns]
   (->> ns ns-interns vals (filter (comp ::test meta))))
+
+(defn run-test*
+  [v]
+  (let [{::keys [cleanup initialize]} (meta v)
+        initial-state (initialize)
+        [_ final-state :as result] (run @v initial-state)]
+    (cleanup final-state)
+    result))
+
+(defmacro run-test
+  "Runs test `test-name`defined with `deftest`"
+  [test-name]
+  `(run-test* (var ~test-name)))

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -50,6 +50,11 @@
     pop-meta
     (m/return ret#)))
 
+(defmacro defflow
+  [sym descr & flows]
+  `(def ~(vary-meta sym assoc ::test true)
+     (flow ~descr ~@flows)))
+
 (defn retry
   "Tries at most n times, returns a vector with true and first element that succeeded
   or false and result of the first try"
@@ -126,3 +131,8 @@
   "Transform a flow step into a state transition function"
   [flow]
   (fn [s] (state/exec flow s)))
+
+(defn ns->flows
+  "Returns all flows defined with `defflow`"
+  [ns]
+  (->> ns ns-interns vals (filter (comp ::test meta))))

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -2,10 +2,7 @@
   (:refer-clojure :exclude [run!])
   (:require [cats.context :as ctx]
             [cats.core :as m]
-            [cats.data :as d]
             [cats.monad.exception :as e]
-            [clojure.test :as ctest :refer [is]]
-            [matcher-combinators.test]
             [midje.checking.core :refer [extended-=]]
             [midje.sweet :refer :all]
             [state-flow.state :as state]

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -87,23 +87,6 @@
          (state/wrap-fn #(do (add-desc-and-meta ~fact-sexp full-desc# ~the-meta)
                              ~left-value))))))
 
-(defn match-expr
-  [desc value checker]
-  (let [test-name (symbol (clojure.string/replace desc " " "-"))]
-    (list `ctest/deftest test-name (list `is (list 'match? checker value)))))
-
-(defmacro match?
-  "Builds a clojure.test test using matcher combinators"
-  [desc value checker]
-  `(flow ~desc
-     [full-desc# (get-description)]
-     (if (state/state? ~value)
-       (m/mlet [extracted-value# ~value]
-         (state/wrap-fn #(do (eval (match-expr full-desc# extracted-value# ~checker))
-                             extracted-value#)))
-       (state/wrap-fn #(do (eval (match-expr full-desc# ~value ~checker))
-                           ~value)))))
-
 (defn run
   [flow initial-state]
   (assert (state/state? flow) "First argument must be a State Monad")

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -41,6 +41,8 @@
     (m/return (description->string desc-list))))
 
 (defmacro flow
+  "Defines a flow"
+  {:style/indent :defn}
   [description & flows]
   `(m/do-let
     (push-meta ~description)

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -85,7 +85,7 @@
        (if (state/state? ~left-value)
          (probe-state full-desc# ~left-value ~right-value ~the-meta)
          (state/wrap-fn #(do (add-desc-and-meta ~fact-sexp full-desc# ~the-meta)
-                       ~left-value))))))
+                             ~left-value))))))
 
 (defn match-expr
   [desc value checker]

--- a/test/state_flow/cljtest_test.clj
+++ b/test/state_flow/cljtest_test.clj
@@ -35,6 +35,13 @@
                  {:value {:a 2 :b 5}
                   :meta {:description []}})))
 
+  (fact "works for failure cases"
+    (let [val {:value {:a 2 :b 5}}]
+      (state-flow/run (cljtest/match? "contains with monadic left value" (state/gets :value) (matchers/equals {:a 1 :b 5})) val)
+      => (d/pair {:a 2 :b 5}
+                 {:value {:a 2 :b 5}
+                  :meta {:description []}})))
+
   (fact "works with matcher combinators in any order"
     (let [val {:value [1 2 3]}]
       (state-flow/run (cljtest/match? "contains with monadic left value" (state/gets :value) (matchers/in-any-order [1 3 2])) val)

--- a/test/state_flow/cljtest_test.clj
+++ b/test/state_flow/cljtest_test.clj
@@ -2,6 +2,7 @@
   (:require [cats.core :as m]
             [cats.data :as d]
             [cats.monad.state :as state]
+            [clojure.test :as ctest]
             [matcher-combinators.matchers :as matchers]
             [matcher-combinators.midje :refer [match]]
             [midje.sweet :refer :all]
@@ -63,6 +64,7 @@
   (flow "Flow declaration here"
     (cljtest/match? "a" increment-two 3)
     (state/swap #(assoc % :yo 1))))
+
 
 (deftest test-with-failure {}
   (flow "Flow declaration here"

--- a/test/state_flow/cljtest_test.clj
+++ b/test/state_flow/cljtest_test.clj
@@ -51,16 +51,16 @@
 
 (facts "defflow"
   (fact "defines flow with default parameters"
-    (macroexpand-1 '(defflow my-flow (match? 1 1)))
+    (macroexpand-1 '(defflow my-flow (cljtest/match? 1 1)))
     => '(clojure.test/deftest
           my-flow
           (state-flow.core/run*
            {}
-           (state-flow.core/flow (clojure.core/str my-flow) (match? 1 1)))))
+           (state-flow.core/flow (clojure.core/str my-flow) (cljtest/match? 1 1)))))
   (fact "defines flow with optional parameters"
-    (macroexpand-1 '(defflow my-flow {:init (constantly {:value 1})} (match? 1 1)))
+    (macroexpand-1 '(defflow my-flow {:init (constantly {:value 1})} (cljtest/match? 1 1)))
       => '(clojure.test/deftest
             my-flow
             (state-flow.core/run*
              {:init (constantly {:value 1})}
-             (state-flow.core/flow (clojure.core/str my-flow) (match? 1 1))))))
+             (state-flow.core/flow (clojure.core/str my-flow) (cljtest/match? 1 1))))))

--- a/test/state_flow/cljtest_test.clj
+++ b/test/state_flow/cljtest_test.clj
@@ -57,15 +57,10 @@
     (cljtest/match? "a" increment-two 3)
     (state/swap #(assoc % :yo 1))))
 
-(deftest test-with-failure
-  "Flow declaration here"
-  (constantly {})
-  (constantly ::cleanup)
-  (cljtest/match? "a" 1 2)
-  (m/mlet [s1 (state/get)]
-          (println s1)
-          (m/return s1))
-  (state/swap #(assoc % :yo 1)))
+(deftest test-with-failure {}
+  (flow "Flow declaration here"
+    (cljtest/match? "a" 1 2)
+    (state/swap #(assoc % :yo 1))))
 
 (facts state-flow/deftest
   (fact "contains proper metadata"
@@ -106,6 +101,10 @@
     (second (test-with-success {}))
     => {:meta {:description []} :yo 1})
 
-  (fact "returns result and runs state functions"
+  (fact "returns result and runs state functions with failure"
+    (second (test-with-failure {}))
+    => {:meta {:description []} :yo 1})
+
+  (fact "returns result and runs state functions (at runtime)"
     (second (test-with-runtime-success {:value 1}))
     => {:meta {:description []} :yo 1 :value 1}))

--- a/test/state_flow/cljtest_test.clj
+++ b/test/state_flow/cljtest_test.clj
@@ -1,0 +1,111 @@
+(ns state-flow.cljtest-test
+  (:require [cats.core :as m]
+            [cats.data :as d]
+            [cats.monad.state :as state]
+            [matcher-combinators.matchers :as matchers]
+            [matcher-combinators.midje :refer [match]]
+            [midje.sweet :refer :all]
+            [state-flow.cljtest :as cljtest :refer [deftest]]
+            [state-flow.core :as state-flow :refer [flow]]
+            [state-flow.state :as sf.state]))
+
+(def increment-two
+  (m/mlet [world (sf.state/get)]
+    (m/return (+ 2 (-> world :value)))))
+
+(facts "on match?"
+
+  (fact "add two to state 1, result is 3, doesn't change world"
+    (state-flow/run (cljtest/match? "test-1" increment-two 3) {:value 1}) => (d/pair 3 {:value 1 :meta {:description []}}))
+
+  (fact "works with non-state values"
+    (state-flow/run (cljtest/match? "test-2" 3 3) {}) => (d/pair 3 {:meta {:description []}}))
+
+  (fact "works with matcher combinators (embeds by default)"
+    (let [val {:value {:a 2 :b 5}}]
+      (state-flow/run (cljtest/match? "contains with monadic left value" (state/gets :value) {:a 2}) val)
+      => (d/pair {:a 2 :b 5}
+                 {:value {:a 2 :b 5}
+                  :meta {:description []}})))
+
+  (fact "works with matcher combinators equals"
+    (let [val {:value {:a 2 :b 5}}]
+      (state-flow/run (cljtest/match? "contains with monadic left value" (state/gets :value) (matchers/equals {:a 2 :b 5})) val)
+      => (d/pair {:a 2 :b 5}
+                 {:value {:a 2 :b 5}
+                  :meta {:description []}})))
+
+  (fact "works with matcher combinators in any order"
+    (let [val {:value [1 2 3]}]
+      (state-flow/run (cljtest/match? "contains with monadic left value" (state/gets :value) (matchers/in-any-order [1 3 2])) val)
+      => (d/pair [1 2 3]
+                 {:value [1 2 3]
+                  :meta {:description []}}))))
+
+(def initial-test-state {::initialized-state true})
+
+(defn initialize-tests-state [] initial-test-state)
+
+(deftest test-with-success {}
+  (flow "Flow declaration here"
+    (cljtest/match? "a" 1 1)
+    (state/swap #(assoc % :yo 1))))
+
+(deftest test-with-runtime-success
+  {:initializer-fn (constantly {:value 1})}
+  (flow "Flow declaration here"
+    (cljtest/match? "a" increment-two 3)
+    (state/swap #(assoc % :yo 1))))
+
+(deftest test-with-failure
+  "Flow declaration here"
+  (constantly {})
+  (constantly ::cleanup)
+  (cljtest/match? "a" 1 2)
+  (m/mlet [s1 (state/get)]
+          (println s1)
+          (m/return s1))
+  (state/swap #(assoc % :yo 1)))
+
+(facts state-flow/deftest
+  (fact "contains proper metadata"
+    (meta #'test-with-success)
+    => (match {:column              number?
+               :file                string?
+               :line                number?
+               :name                'test-with-success
+               ::cljtest/test       true
+               ::cljtest/initialize fn?
+               ::cljtest/cleanup    fn?})
+
+    (meta #'test-with-failure)
+    => (match {:column              number?
+               :file                string?
+               :line                number?
+               :name                'test-with-failure
+               ::cljtest/test       true
+               ::cljtest/initialize fn?
+               ::cljtest/cleanup    fn?}))
+
+  (fact "state functions are properly populated"
+    ((::cljtest/initialize (meta #'test-with-success)))
+    => {}
+
+    ((::cljtest/cleanup (meta #'test-with-success)) {})
+    => {}))
+
+(facts state-flow/ns->tests
+  (fact "only lists flows vars defined in namespace"
+    (cljtest/ns->tests 'state-flow.cljtest-test)
+    => [#'test-with-success
+        #'test-with-runtime-success
+        #'test-with-failure]))
+
+(facts state-flow/run-test
+  (fact "returns result and runs state functions"
+    (second (test-with-success {}))
+    => {:meta {:description []} :yo 1})
+
+  (fact "returns result and runs state functions"
+    (second (test-with-runtime-success {:value 1}))
+    => {:meta {:description []} :yo 1 :value 1}))

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -2,8 +2,9 @@
   (:require [cats.core :as m]
             [cats.data :as d]
             [matcher-combinators.matchers :as matchers]
+            [matcher-combinators.midje :refer [match]]
             [midje.sweet :refer :all]
-            [state-flow.core :as state-flow]
+            [state-flow.core :as state-flow :refer [defflow]]
             [cats.monad.state :as state]
             [state-flow.state :as sf.state]
             [com.stuartsierra.component :as component]))
@@ -136,3 +137,24 @@
 (facts "on as-step-fn"
   (let [increment-two-step (state-flow/as-step-fn (state/swap #(+ 2 %)))]
     (increment-two-step 1) => 3))
+
+
+(defflow flow-with-defflow
+  "Flow declaration here"
+  (println "Hello"))
+
+(facts "on `defflow`"
+  (fact "defines a flow"
+    (state/state? flow-with-defflow)
+    => truthy)
+  (fact "contains proper metadata"
+    (meta #'flow-with-defflow)
+    => (match {:column           number?
+               :file             string?
+               :line             number?
+               :name             'flow-with-defflow
+               ::state-flow/test true})))
+
+(facts "`ns->flows` only lists flows vars defined in namespace"
+  (state-flow/ns->flows 'state-flow.core-test)
+  => [#'flow-with-defflow])


### PR DESCRIPTION
Based on https://github.com/nubank/state-flow/pull/20

* `match?` macro now expands to a clojure.test `testing` and uses `meta` variables from the position it has been written, therefore giving correct line number when a test fails.
* Optional parameters for setting initial-state, cleanup and flow runner

Usage will look something like this:

```clojure
(defflow my-flow
  (match? "simple test" 1 1)
  (match? "embeds" {:a 1 :b 2} {:a 1}))
```
Or with custom parameters:

```clojure
(defflow my-flow {:init aux.init! :runner (comp run! s/with-fn-validation)}
  (match? "simple test" 1 1)
  (match? "simple test 2" 2 2))
```

```clojure
(defflow my-flow {:init (constantly {:value 1
                                     :map {:a 1 :b 2}})}
  [value (state/gets :value)]
  (match? "value is correct" value 1)
  (match? "embeds" (state/gets :map) {:b 2}))
```

example flow migration: https://github.com/nubank/arnaldo/pull/169/files