### PR TITLE
test probing for clojure test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.11.0]
+- Implement test probing for match?
+
 ## [1.10.0]
 - Improved support for clojure test
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "1.10.0"
+(defproject nubank/state-flow "1.11.0"
 
   :description "Postman-like integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -24,6 +24,20 @@
 (defn double-key [k]
   (state/swap (fn [w] (update w k #(* 2 %)))))
 
+(facts state-flow/probe
+  (fact "add two to state 1, result is 3, doesn't change world"
+    (first (state-flow/run (state-flow/probe increment-two #(= % 3)) {:value 1})) => [true 3])
+
+  (fact "add two with small delay"
+    (let [world {:value (atom 0)}]
+      (state-flow/run (delayed-increment-two 100) world) => (d/pair nil world)
+      (state-flow/run (state-flow/probe get-value-state #(= 2 %)) world) => (d/pair [true 2] world)))
+
+  (fact "add two with too much delay"
+    (let [world {:value (atom 0)}]
+      (state-flow/run (delayed-increment-two 4000) world) => (d/pair nil world)
+      (state-flow/run (state-flow/probe get-value-state #(= 2 %)) world) => (d/pair [false 0] world))))
+
 (facts "on verify"
 
   (fact "add two to state 1, result is 3, doesn't change world"


### PR DESCRIPTION
Implements basic test probing functionality for `match?` macro, similar to what is available for `verify`. It can be extended in the future for the parameters to be configurable