### PR TITLE
Fix match parameter order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.0.0]
+- BREAKING CHANGE: `state-flow.cljtest/match?` has a new parameter order to
+  better match `clojure.test/is`
+- Bump dependencies
+- Remove broken tests
+
 ## [1.12.0]
 - Fix license name in `project.clj`
 

--- a/project.clj
+++ b/project.clj
@@ -1,19 +1,19 @@
-(defproject nubank/state-flow "1.12.0"
+(defproject nubank/state-flow "2.0.0"
 
   :description "Postman-like integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}
 
   :plugins [[lein-midje "3.2.1"]
-            [lein-cloverage "1.0.10"]
+            [lein-cloverage "1.1.1"]
             [lein-vanity "0.2.0"]
-            [s3-wagon-private "1.3.1"]
+            [s3-wagon-private "1.3.1" :upgrade false]
             [lein-ancient "0.6.15"]
             [changelog-check "0.1.0"]]
 
-  :dependencies [[org.clojure/clojure "1.9.0"]
+  :dependencies [[org.clojure/clojure "1.10.0"]
                  [com.taoensso/timbre "4.10.0"]
-                 [com.stuartsierra/component "0.3.2"]
+                 [com.stuartsierra/component "0.4.0"]
                  [funcool/cats "2.3.2"]]
 
   :exclusions   [log4j]
@@ -21,9 +21,9 @@
   :profiles {:uberjar {:aot :all}
              :dev {:source-paths ["config"]
                    :dependencies [[ns-tracker "0.3.1"]
-                                  [nubank/matcher-combinators "0.3.4"]
+                                  [nubank/matcher-combinators "0.9.0"]
                                   [org.clojure/tools.namespace "0.2.11"]
-                                  [midje "1.9.1"]
+                                  [midje "1.9.8"]
                                   [org.clojure/java.classpath "0.3.0"]]}}
 
   :aliases {"coverage" ["cloverage" "-s" "coverage"]

--- a/src/state_flow/cljtest.clj
+++ b/src/state_flow/cljtest.clj
@@ -26,7 +26,7 @@
 
 (defmacro match?
   "Builds a clojure.test assertion using matcher combinators"
-  [desc value checker]
+  [checker value desc]
   (let [the-meta (meta &form)]
     `(core/flow ~desc
        [full-desc# (core/get-description)]

--- a/test/state_flow/cljtest_test.clj
+++ b/test/state_flow/cljtest_test.clj
@@ -27,28 +27,28 @@
 (facts "on match?"
 
   (fact "add two to state 1, result is 3, doesn't change world"
-    (state-flow/run (cljtest/match? "test-1" increment-two 3) {:value 1}) => (d/pair 3 {:value 1 :meta {:description []}}))
+    (state-flow/run (cljtest/match? 3 increment-two "test-1") {:value 1}) => (d/pair 3 {:value 1 :meta {:description []}}))
 
   (fact "works with non-state values"
-    (state-flow/run (cljtest/match? "test-2" 3 3) {}) => (d/pair 3 {:meta {:description []}}))
+    (state-flow/run (cljtest/match? 3 3 "test-2") {}) => (d/pair 3 {:meta {:description []}}))
 
   (fact "works with matcher combinators (embeds by default)"
     (let [val {:value {:a 2 :b 5}}]
-      (state-flow/run (cljtest/match? "contains with monadic left value" (state/gets :value) {:a 2}) val)
+      (state-flow/run (cljtest/match? {:a 2} (state/gets :value) "contains with monadic left value") val)
       => (d/pair {:a 2 :b 5}
                  {:value {:a 2 :b 5}
                   :meta {:description []}})))
 
   (fact "works with matcher combinators equals"
     (let [val {:value {:a 2 :b 5}}]
-      (state-flow/run (cljtest/match? "contains with monadic left value" (state/gets :value) (matchers/equals {:a 2 :b 5})) val)
+      (state-flow/run (cljtest/match? (matchers/equals {:a 2 :b 5}) (state/gets :value) "contains with monadic left value") val)
       => (d/pair {:a 2 :b 5}
                  {:value {:a 2 :b 5}
                   :meta {:description []}})))
 
   (fact "works for failure cases"
     (let [val {:value {:a 2 :b 5}}]
-      (state-flow/run (cljtest/match? "contains with monadic left value" (state/gets :value) (matchers/equals {:a 1 :b 5})) val)
+      (state-flow/run (cljtest/match? (matchers/equals {:a 1 :b 5}) (state/gets :value) "contains with monadic left value") val)
       => (d/pair {:a 2 :b 5}
                  {:value {:a 2 :b 5}
                   :meta {:description []}})))
@@ -56,43 +56,43 @@
   (fact "add two with small delay"
     (let [world {:value (atom 0)}]
       (state-flow/run (delayed-increment-two 100) world) => (d/pair nil world)
-      (first (state-flow/run (cljtest/match? "" get-value-state 2) world)) => 2))
+      (first (state-flow/run (cljtest/match? 2 get-value-state "") world)) => 2))
 
   (fact "add two with too much delay (timeout)"
     (let [world {:value (atom 0)}]
       (state-flow/run (delayed-increment-two 4000) world) => (d/pair nil world)
-      (first (state-flow/run (cljtest/match? "" get-value-state 2) world)) => 0))
+      (first (state-flow/run (cljtest/match? 2 get-value-state "") world)) => 0))
 
   (fact "works with matcher combinators in any order"
     (let [val {:value [1 2 3]}]
-      (state-flow/run (cljtest/match? "contains with monadic left value" (state/gets :value) (matchers/in-any-order [1 3 2])) val)
+      (state-flow/run (cljtest/match? (matchers/in-any-order [1 3 2]) (state/gets :value) "contains with monadic left value") val)
       => (d/pair [1 2 3]
                  {:value [1 2 3]
                   :meta {:description []}}))))
 
 (facts "defflow"
   (fact "defines flow with default parameters"
-    (macroexpand-1 '(defflow my-flow (cljtest/match? "equals" 1 1)))
+    (macroexpand-1 '(defflow my-flow (cljtest/match? 1 1 "equals")))
     => '(clojure.test/deftest
           my-flow
           (state-flow.core/run*
             {}
-           (state-flow.core/flow "my-flow" (cljtest/match? "equals" 1 1)))))
+           (state-flow.core/flow "my-flow" (cljtest/match? 1 1 "equals")))))
 
   (fact "defines flow with optional parameters"
-    (macroexpand-1 '(defflow my-flow {:init (constantly {:value 1})} (cljtest/match? "equals" 1 1)))
+    (macroexpand-1 '(defflow my-flow {:init (constantly {:value 1})} (cljtest/match? 1 1 "equals")))
       => '(clojure.test/deftest
             my-flow
             (state-flow.core/run*
               {:init (constantly {:value 1})}
-              (state-flow.core/flow "my-flow" (cljtest/match? "equals" 1 1)))))
+              (state-flow.core/flow "my-flow" (cljtest/match? 1 1 "equals")))))
 
   (fact "defines flow with binding and flow inside match?"
     (macroexpand-1 '(defflow my-flow {:init (constantly {:value 1
                                                          :map {:a 1 :b 2}})}
                       [value (state/gets :value)]
-                      (cljtest/match? value 1)
-                      (cljtest/match? (state/gets :map) {:b 2})))
+                      (cljtest/match? 1 value)
+                      (cljtest/match? {:b 2} (state/gets :map))))
     => '(clojure.test/deftest
           my-flow
           (state-flow.core/run*
@@ -100,14 +100,14 @@
             (state-flow.core/flow
               "my-flow"
               [value (state/gets :value)]
-              (cljtest/match? value 1)
-              (cljtest/match? (state/gets :map) {:b 2}))))))
+              (cljtest/match? 1 value)
+              (cljtest/match? {:b 2} (state/gets :map)))))))
 
 (defflow my-flow {:init (constantly {:value 1
                                      :map {:a 1 :b 2}})}
   [value (state/gets :value)]
-  (cljtest/match? "" value 1)
-  (cljtest/match? "" (state/gets :map) {:b 2}))
+  (cljtest/match? 1 value "")
+  (cljtest/match? {:b 2} (state/gets :map) ""))
 
 (facts "we can run a defined test"
   (second ((:test (meta #'my-flow)))) => {:value 1

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -54,14 +54,7 @@
   (fact "add two with too much delay"
     (def world {:value (atom 0)})
     (state-flow/run (delayed-increment-two 4000) world)
-    (state-flow/run (state-flow/verify "description" get-value-state 0) world))
-
-  (fact "extended equality works"
-    (let [val {:a 2 :b 5}]
-      (state/run (state-flow/probe-state "contains with monadic left value"
-                                         (sf.state/get) (contains {:a 2}) {}) val) => (d/pair val val)
-      (state/run (state-flow/probe-state "just with monadic left value"
-                                         (sf.state/get) (just {:a 2 :b 5}) {}) val) => (d/pair val val))))
+    (state-flow/run (state-flow/verify "description" get-value-state 0) world)))
 
 (def bogus (state/state (fn [s] (throw (Exception. "My exception")))))
 (def increment-two-value


### PR DESCRIPTION
This is to better match `clojure.test/is` semantics (https://clojuredocs.org/clojure.test/is):

- `clojure.test/is`: `(is (= 4 (+ 2 2) "Two plus two should be 4")`
- old `match?`: `(match? "Two plus two should be 4" (+ 2 2) 4)`
- new `match?`: `(match? 4 (+ 2 2) "Two plus two should be 4")`