### PR TITLE
Timeout params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.13.0]
+- Add optional parameters to `match?`, making it possible to tweak times-to-try and sleep-time of test probing 
+
 ## [1.12.1]
 - Fix and update matcher-combinators dependency
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "1.12.1"
+(defproject nubank/state-flow "1.13.0"
 
   :description "Postman-like integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"

--- a/src/state_flow/cljtest.clj
+++ b/src/state_flow/cljtest.clj
@@ -6,7 +6,7 @@
             [state-flow.core :as core]
             [state-flow.state :as state]))
 
-(defn match-expr
+(defn ^:private match-expr
   [desc value checker]
   (let [test-name (symbol (clojure.string/replace desc " " "-"))]
     (list `ctest/testing desc (list `is (list 'match? checker value)))))
@@ -26,12 +26,13 @@
 
 (defmacro match?
   "Builds a clojure.test assertion using matcher combinators"
-  [desc value checker]
-  (let [the-meta (meta &form)]
+  [desc value checker & forms]
+  (let [the-meta (meta &form)
+        params   (if (map? (first forms)) (first forms) {})]
     `(core/flow ~desc
        [full-desc# (core/get-description)]
        (if (state/state? ~value)
-         (m/mlet [extracted-value# (match-probe ~value ~checker)]
+         (m/mlet [extracted-value# (match-probe ~value ~checker ~params)]
            (state/wrap-fn #(do (match+meta full-desc# extracted-value# ~checker ~the-meta)
                                extracted-value#)))
          (state/wrap-fn #(do (match+meta full-desc# ~value ~checker ~the-meta)

--- a/test/state_flow/cljtest_test.clj
+++ b/test/state_flow/cljtest_test.clj
@@ -37,26 +37,32 @@
       (state-flow/run (cljtest/match? "contains with monadic left value" (state/gets :value) {:a 2}) val)
       => (d/pair {:a 2 :b 5}
                  {:value {:a 2 :b 5}
-                  :meta {:description []}})))
+                  :meta  {:description []}})))
 
   (fact "works with matcher combinators equals"
     (let [val {:value {:a 2 :b 5}}]
       (state-flow/run (cljtest/match? "contains with monadic left value" (state/gets :value) (matchers/equals {:a 2 :b 5})) val)
       => (d/pair {:a 2 :b 5}
                  {:value {:a 2 :b 5}
-                  :meta {:description []}})))
+                  :meta  {:description []}})))
 
   (fact "works for failure cases"
     (let [val {:value {:a 2 :b 5}}]
       (state-flow/run (cljtest/match? "contains with monadic left value" (state/gets :value) (matchers/equals {:a 1 :b 5})) val)
       => (d/pair {:a 2 :b 5}
                  {:value {:a 2 :b 5}
-                  :meta {:description []}})))
+                  :meta  {:description []}})))
 
   (fact "add two with small delay"
     (let [world {:value (atom 0)}]
       (state-flow/run (delayed-increment-two 100) world) => (d/pair nil world)
       (first (state-flow/run (cljtest/match? "" get-value-state 2) world)) => 2))
+
+  (fact "we can tweak timeout and times to try"
+    (let [world {:value (atom 0)}]
+      (state-flow/run (delayed-increment-two 100) world) => (d/pair nil world)
+      (first (state-flow/run (cljtest/match? "" get-value-state 2 {:sleep-time   0
+                                                                   :times-to-try 1}) world)) => 0))
 
   (fact "add two with too much delay (timeout)"
     (let [world {:value (atom 0)}]
@@ -68,7 +74,7 @@
       (state-flow/run (cljtest/match? "contains with monadic left value" (state/gets :value) (matchers/in-any-order [1 3 2])) val)
       => (d/pair [1 2 3]
                  {:value [1 2 3]
-                  :meta {:description []}}))))
+                  :meta  {:description []}}))))
 
 (facts "defflow"
   (fact "defines flow with default parameters"


### PR DESCRIPTION
Add optional parameters to `match?`, making it possible to tweak times-to-try and sleep-time of test probing