### PR TITLE
Allow for empty flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.14.0]
+- Allow for empty flows
+
 ## [1.13.0]
 - Add optional parameters to `match?`, making it possible to tweak times-to-try and sleep-time of test probing 
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "1.13.0"
+(defproject nubank/state-flow "1.14.0"
 
   :description "Postman-like integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"

--- a/project.clj
+++ b/project.clj
@@ -15,15 +15,15 @@
                  [com.taoensso/timbre "4.10.0"]
                  [com.stuartsierra/component "0.3.2"]
                  [funcool/cats "2.3.2"]
-                 [nubank/matcher-combinators "0.9.0"]]
+                 [nubank/matcher-combinators "1.1.0"]]
 
   :exclusions   [log4j]
 
   :profiles {:uberjar {:aot :all}
              :dev {:source-paths ["config"]
                    :dependencies [[ns-tracker "0.3.1"]
-                                  [org.clojure/tools.namespace "0.2.11"]
-                                  [midje "1.9.1"]
+                                  [org.clojure/tools.namespace "0.3.0"]
+                                  [midje "1.9.9"]
                                   [org.clojure/java.classpath "0.3.0"]]}}
 
   :aliases {"coverage" ["cloverage" "-s" "coverage"]

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -41,11 +41,13 @@
   "Defines a flow"
   {:style/indent :defn}
   [description & flows]
-  `(m/do-let
-    (push-meta ~description)
-    [ret# (m/do-let ~@flows)]
-    pop-meta
-    (m/return ret#)))
+  (let [flows' (or flows
+                   '[(state/swap identity)])]
+    `(m/do-let
+       (push-meta ~description)
+       [ret# (m/do-let ~@flows')]
+       pop-meta
+       (m/return ret#))))
 
 (defn retry
   "Tries at most n times, returns a vector with true and first element that succeeded

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -87,6 +87,9 @@
     (state-flow/flow "child1" increment-two-value)
     (state-flow/flow "child2" bogus increment-two-value)))
 
+(def empty-flow
+  (state-flow/flow "empty"))
+
 (fact "on push-meta"
   (state/exec (m/>> (state-flow/push-meta "mydesc")
                     (state-flow/push-meta "mydesc2")) {}) => {:meta {:description ["mydesc"  "mydesc2"]}})
@@ -104,6 +107,11 @@
     (second (state-flow/run nested-flow {:value 0}))
     => {:meta {:description []}
         :value 4})
+
+  (fact "empty flow"
+    (second (state-flow/run empty-flow {:value 0}))
+    => {:meta {:description []}
+        :value 0})
 
   (fact "nested-flow-with exception, returns exception and state before exception"
     (let [[left right] (state-flow/run bogus-flow {:value 0})]


### PR DESCRIPTION
Not sure if this is behavior you want to support but here goes:

I was trying to wire up my first `state-flow` flow and was encountering a few exceptions. I wanted to isolate the error, so I started deleting steps in the flow until I had 
```clojure
(defflow foo)
```
which I assumed would be the smallest flow I could use to determine if the exception had to do with my test running setup or the actual flow definition.

When I did this I got:

```
Unexpected error (AssertionError) macroexpanding cats.core/do-let at (postman/copy
_record_series_test.clj:42:1).
Assert failed: do-let must have at least one argument
(not (empty? forms))
```

This PR puts forward the change that treats empty flows as running the identity step on the initial input provided.
One could argue that `(defflow foo)` is by construction malformed because steps should always be provided in a flow. If that is the case then I'd suggest changing `state-flow.core/flow` to 

```clojure
(defmacro flow
  "Defines a flow"
  {:style/indent :defn}
  [description & flows]
  (assert (seq flows) "Flows must be non-empty")
  `(m/do-let
     ...))
```