### PR TITLE
Require flows to have a string desc to prevent using 1st subflow as the description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.15.0]
+- Require flows to have a string description to prevent the first subflow from
+  being used as the description.
+
 ## [1.14.0]
 - Allow for empty flows
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "1.14.0"
+(defproject nubank/state-flow "1.15.0"
 
   :description "Postman-like integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -41,6 +41,8 @@
   "Defines a flow"
   {:style/indent :defn}
   [description & flows]
+  (when-not (string? description)
+    (throw (IllegalArgumentException. "The first argument of the flow must be a description string")))
   (let [flows' (or flows
                    '[(state/swap identity)])]
     `(m/do-let

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -90,9 +90,6 @@
 (def empty-flow
   (state-flow/flow "empty"))
 
-(def flow-with-description-missing
-  )
-
 (fact "on push-meta"
   (state/exec (m/>> (state-flow/push-meta "mydesc")
                     (state-flow/push-meta "mydesc2")) {}) => {:meta {:description ["mydesc"  "mydesc2"]}})


### PR DESCRIPTION
I was trying to call `state-flow.core/flow` for the first time and I didn't realize that you need to pass it a description as the first arg (given that in `selvage` flows the description is optional).
Without the description arg
```clojure
(state-flow/flow [original (state/gets :value)
                  :let [doubled (* 2 original)]]
                 (sf.state/swap #(assoc % :value doubled)))
```
results in 
```
CompilerException java.lang.RuntimeException: Unable to resolve symbol: original in this context
, compiling:(state_flow/core_test.clj:120:5)
```
because the first subflow gets used as the description and hence the binding of `original` gets lost.

The solution I came up with was to assert at compile time that the `description` argument to the `flow` macro is a string. This means that if you use a variable that points to a string instead of a string, the flow expression will fail at compile time even though it would resolve to a string description at runtime.

An alternative approach would be to allow variables pointing to strings as the `description` argument, and check it at runtime instead of compile time:

```clojure
(defmacro flow
  "Defines a flow"
  {:style/indent :defn}
  [description & flows]
  (let [flows' (or flows
                   '[(state/swap identity)])]
    `(do
       (when-not (string? ~description)
         (throw (IllegalArgumentException. "The first argument of the flow must be a description string")))
       (m/do-let
         (push-meta ~description)
         ...))))
```

I don't see a clear winner; any opinions?
