### PR TITLE
wrapper-fn defflow parameter to allow for with-redefing a whole flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.15.0]
+- add `:wrapper-fn` parameter to `defflow` parameters, which allows you to wrap a whole flow with things like `with-redefs`.
+
 ## [1.14.0]
 - Allow for empty flows
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "1.14.0"
+(defproject nubank/state-flow "1.15.0"
 
   :description "Postman-like integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"

--- a/src/state_flow/cljtest.clj
+++ b/src/state_flow/cljtest.clj
@@ -44,6 +44,9 @@
   [name & forms]
   (let [[parameters & flows] (if (map? (first forms))
                                forms
-                               (cons {} forms))]
+                               (cons {} forms))
+        wrapper              (or (:wrapper-fn parameters)
+                                 (fn [flow] (flow)))
+        flow-parameters      (dissoc parameters :wrapper-fn)]
     `(ctest/deftest ~name
-       (core/run* ~parameters (core/flow ~(str name) ~@flows)))))
+       (~wrapper (core/run* ~flow-parameters (core/flow ~(str name) ~@flows))))))

--- a/test/state_flow/cljtest_test.clj
+++ b/test/state_flow/cljtest_test.clj
@@ -119,3 +119,12 @@
   (second ((:test (meta #'my-flow)))) => {:value 1
                                           :map   {:a 1 :b 2}
                                           :meta  {:description []}})
+
+(defn foo [] 1)
+
+(defn wrapper [flow]
+  (with-redefs [foo (constantly 2)]
+    (flow)))
+
+(defflow only-works-with-wrapper {:wrapper-fn wrapper}
+  (cljtest/match? "" (foo) 2))


### PR DESCRIPTION
I want to redef `call-async` for an entire defflow, just like can be done for `midje` flows:
https://github.com/nubank/purgatory/blob/45296d3e6d5111086f4e0606bdca879b32a56af7/postman/postman/delinquent.clj#L117

It isn't currently possible, but the same issue was solved in `selvage` by introducing a `:wrapper-fn` parameter to `defflow` and wrapping the whole `run` in that wrapper.

If people like this approach I'll
 - write docs in the readme
 - update the `defflow` docstring to mention `:wrapper-fn`