### PR TITLE
Allow str expr to be valid flow desc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.15.1]
+- Allow `(str ...)` to be a valid flow description
+
 ## [1.15.0]
 - Require flows to have a string description to prevent the first subflow from
   being used as the description.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "1.15.0"
+(defproject nubank/state-flow "1.15.1"
 
   :description "Postman-like integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -37,7 +37,7 @@
 
 (defn string-expr? [x]
   (or (string? x)
-      (and (sequential? x)
+      (and (list? x)
            (or (= (first x) 'str)
                (= (first x) 'clojure.core/str)))))
 

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -37,11 +37,17 @@
   (m/mlet [desc-list (state/gets #(-> % :meta :description))]
     (m/return (description->string desc-list))))
 
+(defn string-expr? [x]
+  (or (string? x)
+      (and (sequential? x)
+           (or (= (first x) 'str)
+               (= (first x) 'clojure.core/str)))))
+
 (defmacro flow
   "Defines a flow"
   {:style/indent :defn}
   [description & flows]
-  (when-not (string? description)
+  (when-not (string-expr? description)
     (throw (IllegalArgumentException. "The first argument of the flow must be a description string")))
   (let [flows' (or flows
                    '[(state/swap identity)])]

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -119,6 +119,12 @@
                                        (sf.state/swap #(assoc % :value doubled))))
         => (throws IllegalArgumentException))
 
+  (fact "flow with a `(str ..)` expr for the description is fine"
+      (macroexpand `(state-flow/flow (str "foo") [original (state/gets :value)
+                                                  :let [doubled (* 2 original)]]
+                                     (sf.state/swap #(assoc % :value doubled))))
+        => list?)
+
   (fact "but flows with an expression that resolves to a string also aren't valid,
         due to resolution limitations at macro-expansion time"
         (let [my-desc "trolololo"]


### PR DESCRIPTION
follow-up to https://github.com/nubank/state-flow/pull/31 which will allow for us to build better sub-flow description strings.

For example
```clojure
(defn my-subflow [arg1]
  (flow (str "my-subflow with arg" arg1) ...))
```