### PR TITLE
isolate Midje by moving `verify` to dedicated namespace [breaking]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [2.0.0]
+- [BREAKING] Move `verify` to `state-flow.midje` namespace.
+
 ## [1.15.1]
 - Add alias for m/return as state/return
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [2.0.0]
-- [BREAKING] Move `verify` to `state-flow.midje` namespace.
+- [BREAKING] Move `verify` to from `state-flow.core` to the `state-flow.midje` namespace.
 
 ## [1.15.1]
 - Add alias for m/return as state/return

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Or we could increment the value first and then return it doubled:
 ## Clojure.test Support
 
 The way we can use flows to make `clojure.test` tests is by using `match?`.
-`match?` is a flow that will make a `clojure.test` assertion and the `nubank/matcher-combinators` library
+`match?` is a flow that will make a `clojure.test` assertion and the [`nubank/matcher-combinators`](https://github.com/nubank/matcher-combinators/) library
 for the actual checking and failure messages. `match?` asks for a string description, a value (or a flow returning a value) and a matcher-combinators matcher (or value to be checked against). Not passing a matcher defaults to `matchers/embeds` behaviour.
 
 The assertions should be wrapped in a `defflow`. `defflow` will define a test (using `deftest`)
@@ -161,7 +161,8 @@ and we also have a step that fetches this data from db (`fetch-data`). We want t
 
 ```clojure
 (:require
-  [state-flow.core :refer [flow verify]])
+  [state-flow.core :refer [flow]]
+  [state-flow.midje :refer [verify]])
 
 (defn stores-data-in-db
   [data]

--- a/project.clj
+++ b/project.clj
@@ -10,9 +10,9 @@
             [lein-ancient "0.6.15"]
             [changelog-check "0.1.0"]]
 
-  :dependencies [[org.clojure/clojure "1.9.0"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
                  [com.taoensso/timbre "4.10.0"]
-                 [com.stuartsierra/component "0.3.2"]
+                 [com.stuartsierra/component "0.4.0"]
                  [funcool/cats "2.3.2"]
                  [nubank/matcher-combinators "1.2.1"]]
 
@@ -20,8 +20,8 @@
 
   :profiles {:uberjar {:aot :all}
              :dev {:source-paths ["config"]
-                   :dependencies [[ns-tracker "0.3.1"]
-                                  [org.clojure/tools.namespace "0.3.0"]
+                   :dependencies [[ns-tracker "0.4.0"]
+                                  [org.clojure/tools.namespace "0.3.1"]
                                   [midje "1.9.9"]
                                   [org.clojure/java.classpath "0.3.0"]]}}
 

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
                  [com.taoensso/timbre "4.10.0"]
                  [com.stuartsierra/component "0.3.2"]
                  [funcool/cats "2.3.2"]
-                 [nubank/matcher-combinators "1.1.0"]]
+                 [nubank/matcher-combinators "1.2.1"]]
 
   :exclusions   [log4j]
 

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,4 @@
-(defproject nubank/state-flow "1.15.1"
-
+(defproject nubank/state-flow "2.0.0"
   :description "Postman-like integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -3,8 +3,6 @@
   (:require [cats.context :as ctx]
             [cats.core :as m]
             [cats.monad.exception :as e]
-            [midje.checking.core :refer [extended-=]]
-            [midje.sweet :refer :all]
             [state-flow.state :as state]
             [taoensso.timbre :as log]))
 
@@ -71,32 +69,6 @@
      (m/return result)))
   ([state check-fn]
    (probe state check-fn {:sleep-time sleep-time :times-to-try times-to-try})))
-
-(defmacro add-desc-and-meta
-  [[fname & rest] desc meta]
-  (with-meta `(~fname {:midje/name ~desc} ~@rest) meta))
-
-(defmacro verify-probe
-  "Given a fact description, a state and a right-value,
-  returns a State that runs left up to times-to-retry times every sleep-time ms until left-value equals right value."
-  [desc state right-value metadata]
-  `(ctx/with-context (ctx/infer ~state)
-     (m/mlet [[_# result#] (probe ~state #(extended-= % ~right-value))]
-       (do (add-desc-and-meta (fact result# => ~right-value) ~desc ~metadata)
-           (m/return result#)))))
-
-(defmacro verify
-  "If left-value is a state, do fact probing. Otherwise, regular fact checking.
-  Push and pop descriptions (same behaviour of flow)"
-  [desc left-value right-value]
-  (let [the-meta  (meta &form)
-        fact-sexp `(fact ~left-value => ~right-value)]
-    `(flow ~desc
-       [full-desc# (get-description)]
-       (if (state/state? ~left-value)
-         (verify-probe full-desc# ~left-value ~right-value ~the-meta)
-         (state/wrap-fn #(do (add-desc-and-meta ~fact-sexp full-desc# ~the-meta)
-                             ~left-value))))))
 
 (defn run
   [flow initial-state]

--- a/src/state_flow/midje.clj
+++ b/src/state_flow/midje.clj
@@ -1,0 +1,33 @@
+(ns state-flow.midje
+  (:require [cats.context :as ctx]
+            [cats.core :as m]
+            [midje.checking.core :refer [extended-=]]
+            [midje.sweet :refer :all]
+            [state-flow.core :as core]
+            [state-flow.state :as state]))
+
+(defmacro add-desc-and-meta
+  [[fname & rest] desc meta]
+  (with-meta `(~fname {:midje/name ~desc} ~@rest) meta))
+
+(defmacro verify-probe
+  "Given a fact description, a state and a right-value,
+  returns a State that runs left up to times-to-retry times every sleep-time ms until left-value equals right value."
+  [desc state right-value metadata]
+  `(ctx/with-context (ctx/infer ~state)
+     (m/mlet [[_# result#] (core/probe ~state #(extended-= % ~right-value))]
+       (do (add-desc-and-meta (fact result# => ~right-value) ~desc ~metadata)
+           (m/return result#)))))
+
+(defmacro verify
+  "If left-value is a state, do fact probing. Otherwise, regular fact checking.
+  Push and pop descriptions (same behaviour of flow)"
+  [desc left-value right-value]
+  (let [the-meta  (meta &form)
+        fact-sexp `(fact ~left-value => ~right-value)]
+    `(core/flow ~desc
+       [full-desc# (core/get-description)]
+       (if (state/state? ~left-value)
+         (verify-probe full-desc# ~left-value ~right-value ~the-meta)
+         (state/wrap-fn #(do (add-desc-and-meta ~fact-sexp full-desc# ~the-meta)
+                             ~left-value))))))

--- a/test/state_flow/midje_test.clj
+++ b/test/state_flow/midje_test.clj
@@ -1,0 +1,34 @@
+(ns state-flow.midje-test
+  (:require [cats.core :as m]
+            [cats.data :as d]
+            [cats.monad.state :as state]
+            [midje.sweet :refer :all]
+            [state-flow.core :as state-flow]
+            [state-flow.midje :as midje]
+            [state-flow.state :as sf.state]
+            [state-flow.test-helpers :as test-helpers]))
+
+(facts "on verify"
+
+  (fact "add two to state 1, result is 3, doesn't change world"
+    (state-flow/run (midje/verify "description" test-helpers/increment-two 3) {:value 1}) => (d/pair 3 {:value 1 :meta {:description []}}))
+
+  (fact "works with non-state values"
+    (state-flow/run (midje/verify "description" 3 3) {}) => (d/pair 3 {:meta {:description []}}))
+
+  (fact "add two with small delay"
+    (def world {:value (atom 0)})
+    (state-flow/run (test-helpers/delayed-increment-two 100) world) => (d/pair nil world)
+    (state-flow/run (midje/verify "description" test-helpers/get-value-state 2) world) => (d/pair 2 (merge world {:meta {:description []}})))
+
+  (fact "add two with too much delay"
+    (def world {:value (atom 0)})
+    (state-flow/run (test-helpers/delayed-increment-two 4000) world)
+    (state-flow/run (midje/verify "description" test-helpers/get-value-state 0) world))
+
+  (fact "extended equality works"
+    (let [val {:a 2 :b 5}]
+      (state/run (midje/verify-probe "contains with monadic left value"
+                                     (sf.state/get) (contains {:a 2}) {}) val) => (d/pair val val)
+      (state/run (midje/verify-probe "just with monadic left value"
+                                     (sf.state/get) (just {:a 2 :b 5}) {}) val) => (d/pair val val))))

--- a/test/state_flow/test_helpers.clj
+++ b/test/state_flow/test_helpers.clj
@@ -4,6 +4,7 @@
             [cats.monad.state :as state]
             [state-flow.state :as sf.state]))
 
+(def get-value (comp deref :value))
 (def get-value-state (state/gets get-value))
 
 (def increment-two

--- a/test/state_flow/test_helpers.clj
+++ b/test/state_flow/test_helpers.clj
@@ -1,0 +1,20 @@
+(ns state-flow.test-helpers
+  (:require [cats.core :as m]
+            [cats.data :as d]
+            [cats.monad.state :as state]
+            [state-flow.state :as sf.state]))
+
+(def get-value-state (state/gets get-value))
+
+(def increment-two
+  (m/mlet [world (sf.state/get)]
+    (m/return (+ 2 (-> world :value)))))
+
+(defn delayed-increment-two
+  [delay-ms]
+  "Changes world in the future"
+  (state/state (fn [world]
+                 (future (do (Thread/sleep delay-ms)
+                             (swap! (:value world) + 2)))
+                 (d/pair nil world))))
+


### PR DESCRIPTION
For those who don't want to use `midje`, it would be nice to be able to do something like `[nubank/state-flow "2.0.0" :exclusions [midje]]` and not have to wait for all the midje namespaces to load when using `state-flow`, especially during repl dev, where `Run `(doc midje)` for Midje usage.` seems to take a long time.

### breaking change
This is a breaking change, and given code like 
```clojure
(ns postman.agreement
  (:require ...
            [state-flow.core :refer [flow verify]]))

(init/run!
 (flow "my flow"
   [customer setup-customer]

   (verify "customer has name" identity (:name customer))))
```
The `verify` require would need to change like this:
```clojure
(ns postman.agreement
  (:require ...
            [state-flow.midje :refer [verify]]))
            [state-flow.core :refer [flow]]))

(init/run!
  ...)
```

### speed impact
Given some random test
```clojure
(def nested-flow
  (state-flow/flow "root"
    (state-flow/flow "child1" increment-two-value)
    (match? "value incremented by 4"
      (state/gets #(-> % :value)) 4)))

(defflow whatever {:init (constantly {:value 2})} nested-flow)
```
This takes currently takes ~10 seconds
After the changes in this PR, it takes ~8 seconds

~Note: if people like this proposal then I'll take the time to fix the tests~