### PR TITLE
Make state-flow.state/swap work more like Clojure's swap

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ fetches the `<value>` inside `<number>`:
 For updating the state we can use `state/swap`. If we want to write a flow that will increment value by one, it could be done like this:
 
 ```clojure
-(def inc-value (state/swap #(update-in % [:value] inc)))
+(def inc-value (state/swap update :value inc)))
 (state-flow/run! inc-value {:value 4})
 ; => [{:value 4} {:value 5}]
 ```

--- a/samples/tutorial.clj
+++ b/samples/tutorial.clj
@@ -21,7 +21,7 @@ Runner
 (state-flow/run! get-value {:value 4})
 ; => [4 {:value 4}]
 
-(def inc-value (state/swap #(update-in % [:value] inc)))
+(def inc-value (state/swap update :value inc))
 (state-flow/run! inc-value {:value 4})
 ; => [{:value 4} {:value 5}]
 
@@ -100,5 +100,3 @@ Asynchronous tests
 
 (state-flow/run! with-async-success {:value (atom 4)})
 ;=> [5 {:value (atom 5)}]
-
-

--- a/src/state_flow/state.clj
+++ b/src/state_flow/state.clj
@@ -68,8 +68,8 @@
   (state/put s error-context))
 
 (defn swap
-  [f]
-  (state/swap f error-context))
+  [f & args]
+  (state/swap (fn [s] (apply f s args)) error-context))
 
 (defn wrap-fn
   "Wraps a (possibly side-effecting) function to a state monad"

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -41,7 +41,7 @@
   (state-flow/flow "root"
     [original (state/gets :value)
      :let [doubled (* 2 original)]]
-    (sf.state/swap #(assoc % :value doubled))
+    (sf.state/swap assoc :value doubled)
     (midje/verify "value is doubled"
       (state/gets #(-> % :value)) doubled)))
 
@@ -79,13 +79,13 @@
   (fact "flow without description fails at macro-expansion time"
         (macroexpand `(state-flow/flow [original (state/gets :value)
                                         :let [doubled (* 2 original)]]
-                                       (sf.state/swap #(assoc % :value doubled))))
+                                        (sf.state/swap assoc :value doubled)))
         => (throws IllegalArgumentException))
 
   (fact "flow with a `(str ..)` expr for the description is fine"
       (macroexpand `(state-flow/flow (str "foo") [original (state/gets :value)
                                                   :let [doubled (* 2 original)]]
-                                     (sf.state/swap #(assoc % :value doubled))))
+                                                  (sf.state/swap assoc :value doubled)))
         => list?)
 
   (fact "but flows with an expression that resolves to a string also aren't valid,
@@ -93,7 +93,7 @@
         (let [my-desc "trolololo"]
           (macroexpand `(state-flow/flow ~'my-desc [original (state/gets :value)
                                                     :let [doubled (* 2 original)]]
-                                         (sf.state/swap #(assoc % :value doubled)))))
+                                                    (sf.state/swap assoc :value doubled))))
         => (throws IllegalArgumentException))
 
   (fact "nested-flow-with exception, returns exception and state before exception"

--- a/test/state_flow/state_test.clj
+++ b/test/state_flow/state_test.clj
@@ -13,7 +13,7 @@
            _ (sf.state/put (+ x 1))]
     (m/return x)))
 
-(def double-state (sf.state/swap #(* 2 %)))
+(def double-state (sf.state/swap * 2))
 
 (fact "postincrement"
   (state/run postincrement 1) => (d/pair 1 2))


### PR DESCRIPTION
Many of Clojure's higher-order functions like update, update-in, swap!, etc, take varargs in order to support passing a function and it's arguments as first class arguments rather than wrapping it all up in an anonymous function e.g.

``` clojure
(update {:a 1} :a + 2)

;; vs

(update {:a 1} :a #(+ % 2))
```

This PR makes `state-flow.state/swap` work the same way. This is backward compatible: you can still provide a single function argument, but you can choose to use the more idiomatic approach.

``` clojure
;; both of these work

(def inc-value (state/swap update :value inc)))

(def inc-value (state/swap #(update-in % [:value] inc)))
```