### PR TITLE
use Haskell's names for State monad functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.0.3]
+- Add `state-flow.state/modify` to align with rest of the fn names from Haskell's State Monad
+- Deprecate `state-flow.state/swap` (use `modify` instead)
+
 ## [2.0.2]
 - Update cats and matcher-combinators to latest versions
 
@@ -20,7 +24,7 @@
 - Allow for empty flows
 
 ## [1.13.0]
-- Add optional parameters to `match?`, making it possible to tweak times-to-try and sleep-time of test probing 
+- Add optional parameters to `match?`, making it possible to tweak times-to-try and sleep-time of test probing
 
 ## [1.12.1]
 - Fix and update matcher-combinators dependency

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ a system using [Stuart Sierra's Component](https://github.com/stuartsierra/compo
 Primitives are the fundamental building blocks of flows and are
 enough to build any kind of flow. Each one returns a function of the
 state. These functions are wrapped in Records in order to support
-background processing, but you can just think of them as functions.
+Protocols, but you can just think of them as functions.
 
 Below we list the main primitives and a model for the sort of function
 each represents. The names of the primatives are derived from

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "2.0.2"
+(defproject nubank/state-flow "2.0.3"
   :description "Postman-like integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}

--- a/samples/tutorial.clj
+++ b/samples/tutorial.clj
@@ -9,7 +9,7 @@ The primitive steps
 
 (state/gets getter) => (fn [s] [(getter s) s])
 
-(state/swap setter) => (fn [s] [s (setter s)])
+(state/modify setter) => (fn [s] [s (setter s)])
 
 (m/return value) => (fn [s] [value s])
 """
@@ -21,7 +21,7 @@ Runner
 (state-flow/run! get-value {:value 4})
 ; => [4 {:value 4}]
 
-(def inc-value (state/swap #(update-in % [:value] inc)))
+(def inc-value (state/modify #(update % :value inc)))
 (state-flow/run! inc-value {:value 4})
 ; => [{:value 4} {:value 5}]
 
@@ -77,10 +77,10 @@ Tests
 Asynchronous tests
 """
 (def delayed-inc-value
-  (state/swap (fn [world]
-                (future (do (Thread/sleep 200)
-                            (swap! (:value world) inc)))
-                world)))
+  (state/modify (fn [world]
+                  (future (do (Thread/sleep 200)
+                              (swap! (:value world) inc)))
+                  world)))
 
 (def get-value-deref
   (state/gets (comp deref :value)))
@@ -100,5 +100,3 @@ Asynchronous tests
 
 (state-flow/run! with-async-success {:value (atom 4)})
 ;=> [5 {:value (atom 5)}]
-
-

--- a/src/state_flow/state.clj
+++ b/src/state_flow/state.clj
@@ -60,16 +60,34 @@
 (util/make-printable (type error-context))
 
 (defn get
+  "Returns the equivalent of (fn [state] [state, state])"
   []
   (state/get error-context))
 
-(defn put
-  [s]
-  (state/put s error-context))
+(defn gets
+  [f]
+  "Returns the equivalent of (fn [state] [state, (f state)])"
+  (state/gets f))
 
-(defn swap
+(defn put
+  "Returns the equivalent of (fn [state] [state, new-state])"
+  [new-state]
+  (state/put new-state error-context))
+
+(defn modify
+  "Returns the equivalent of (fn [state] [state, (swap! state f)])"
   [f]
   (state/swap f error-context))
+
+(defn return
+  "Returns the equivalent of (fn [state] [v, state])"
+  [v]
+  (m/return v))
+
+(defn ^:deprecated swap
+  "DEPRECATED: use modify"
+  [f]
+  (modify f))
 
 (defn wrap-fn
   "Wraps a (possibly side-effecting) function to a state monad"
@@ -82,5 +100,3 @@
 (def run state/run)
 (def eval state/eval)
 (def exec state/exec)
-(def gets state/gets)
-(def return m/return)

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -41,7 +41,7 @@
   (state-flow/flow "root"
     [original (state/gets :value)
      :let [doubled (* 2 original)]]
-    (sf.state/swap #(assoc % :value doubled))
+    (sf.state/modify #(assoc % :value doubled))
     (midje/verify "value is doubled"
       (state/gets #(-> % :value)) doubled)))
 
@@ -79,13 +79,13 @@
   (fact "flow without description fails at macro-expansion time"
         (macroexpand `(state-flow/flow [original (state/gets :value)
                                         :let [doubled (* 2 original)]]
-                                       (sf.state/swap #(assoc % :value doubled))))
+                                       (sf.state/modify #(assoc % :value doubled))))
         => (throws IllegalArgumentException))
 
   (fact "flow with a `(str ..)` expr for the description is fine"
       (macroexpand `(state-flow/flow (str "foo") [original (state/gets :value)
                                                   :let [doubled (* 2 original)]]
-                                     (sf.state/swap #(assoc % :value doubled))))
+                                     (sf.state/modify #(assoc % :value doubled))))
         => list?)
 
   (fact "but flows with an expression that resolves to a string also aren't valid,
@@ -93,7 +93,7 @@
         (let [my-desc "trolololo"]
           (macroexpand `(state-flow/flow ~'my-desc [original (state/gets :value)
                                                     :let [doubled (* 2 original)]]
-                                         (sf.state/swap #(assoc % :value doubled)))))
+                                         (sf.state/modify #(assoc % :value doubled)))))
         => (throws IllegalArgumentException))
 
   (fact "nested-flow-with exception, returns exception and state before exception"

--- a/test/state_flow/state_test.clj
+++ b/test/state_flow/state_test.clj
@@ -13,7 +13,7 @@
            _ (sf.state/put (+ x 1))]
     (m/return x)))
 
-(def double-state (sf.state/swap #(* 2 %)))
+(def double-state (sf.state/modify #(* 2 %)))
 
 (fact "postincrement"
   (state/run postincrement 1) => (d/pair 1 2))
@@ -30,7 +30,7 @@
 (def will-fail
   (m/>> double-state
         double-state
-        (sf.state/swap (fn [s] (throw (Exception. "My exception"))))
+        (sf.state/modify (fn [s] (throw (Exception. "My exception"))))
         double-state))
 
 (fact "Error short-circuits execution"


### PR DESCRIPTION
This PR deprecates the `swap` function, which sounds like a Clojure core function, but works differently, and replaces it with the `modify` function, aligning all of the state primitives with the language of Haskell's State Monad: https://wiki.haskell.org/State_Monad

It also `defn`s the `gets` and `return` functions to support documentation than supported by just passing them through a `def`.