### PR TITLE
set times-to-try to 3, not 100; and add linters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [2.0.3]
+- update `times-to-try` default from `100` to `3`
+
 ## [2.0.2]
 - Update cats and matcher-combinators to latest versions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [2.0.3]
-- update `times-to-try` default from `100` to `3`
+- update `times-to-try` default from `100` to `5` and `sleep-time` default from `10` to `200`
 
 ## [2.0.2]
 - Update cats and matcher-combinators to latest versions

--- a/project.clj
+++ b/project.clj
@@ -8,15 +8,20 @@
             [lein-vanity "0.2.0"]
             [s3-wagon-private "1.3.1"]
             [lein-ancient "0.6.15"]
+            [lein-cljfmt "0.6.1"]
+            [lein-nsorg "0.2.0"]
             [changelog-check "0.1.0"]]
 
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [com.taoensso/timbre "4.10.0"]
                  [com.stuartsierra/component "0.4.0"]
                  [funcool/cats "2.3.3"]
-                 [nubank/matcher-combinators "1.2.4"]]
+                 [nubank/matcher-combinators "1.2.6"]]
 
   :exclusions   [log4j]
+
+  :cljfmt {:indents {mlet [[:block 1]]
+                     flow [[:block 1]]}}
 
   :profiles {:uberjar {:aot :all}
              :dev {:source-paths ["config"]
@@ -26,6 +31,8 @@
                                   [org.clojure/java.classpath "0.3.0"]]}}
 
   :aliases {"coverage" ["cloverage" "-s" "coverage"]
+            "lint"     ["do" ["cljfmt" "check"] ["nsorg"]]
+            "lint-fix" ["do" ["cljfmt" "fix"] ["nsorg" "--replace"]]
             "loc"      ["vanity"]}
 
   :repl-options  {:init-ns user}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "2.0.2"
+(defproject nubank/state-flow "2.0.3"
   :description "Postman-like integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}

--- a/project.clj
+++ b/project.clj
@@ -20,8 +20,10 @@
 
   :exclusions   [log4j]
 
-  :cljfmt {:indents {mlet [[:block 1]]
-                     flow [[:block 1]]}}
+  :cljfmt {:indents {mlet  [[:block 1]]
+                     facts [[:block 1]]
+                     fact  [[:block 1]]
+                     flow  [[:block 1]]}}
 
   :profiles {:uberjar {:aot :all}
              :dev {:source-paths ["config"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "2.0.3"
+(defproject nubank/state-flow "2.0.4"
   :description "Postman-like integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}

--- a/src/state_flow/cljtest.clj
+++ b/src/state_flow/cljtest.clj
@@ -1,8 +1,8 @@
 (ns state-flow.cljtest
   (:require [cats.core :as m]
             [clojure.test :as ctest :refer [is]]
-            [matcher-combinators.test]
             [matcher-combinators.core :as matcher-combinators]
+            [matcher-combinators.test]
             [state-flow.core :as core]
             [state-flow.state :as state]))
 

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -50,10 +50,10 @@
   (let [flows' (or flows
                    '[(state/swap identity)])]
     `(m/do-let
-       (push-meta ~description)
-       [ret# (m/do-let ~@flows')]
-       pop-meta
-       (m/return ret#))))
+      (push-meta ~description)
+      [ret# (m/do-let ~@flows')]
+      pop-meta
+      (m/return ret#))))
 
 (defn retry
   "Tries at most n times, returns a vector with true and first element that succeeded

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -6,8 +6,8 @@
             [state-flow.state :as state]
             [taoensso.timbre :as log]))
 
-(def sleep-time 10)
-(def times-to-try 3)
+(def sleep-time 200)
+(def times-to-try 5)
 
 (defn update-description
   [old new]

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -7,7 +7,7 @@
             [taoensso.timbre :as log]))
 
 (def sleep-time 10)
-(def times-to-try 100)
+(def times-to-try 3)
 
 (defn update-description
   [old new]

--- a/src/state_flow/state.clj
+++ b/src/state_flow/state.clj
@@ -29,7 +29,6 @@
     (-mreturn [_ v]
       (state/state (partial d/pair v) error-context))
 
-
     (-mbind [_ self f]
       (state/state (fn [s]
                      (let [mp ((e/wrap (p/-extract self)) s)]

--- a/test/state_flow/cljtest_test.clj
+++ b/test/state_flow/cljtest_test.clj
@@ -82,16 +82,16 @@
     => '(clojure.test/deftest
           my-flow
           (state-flow.core/run*
-            {}
+           {}
            (state-flow.core/flow "my-flow" (cljtest/match? "equals" 1 1)))))
 
   (fact "defines flow with optional parameters"
     (macroexpand-1 '(defflow my-flow {:init (constantly {:value 1})} (cljtest/match? "equals" 1 1)))
-      => '(clojure.test/deftest
-            my-flow
-            (state-flow.core/run*
-              {:init (constantly {:value 1})}
-              (state-flow.core/flow "my-flow" (cljtest/match? "equals" 1 1)))))
+    => '(clojure.test/deftest
+          my-flow
+          (state-flow.core/run*
+           {:init (constantly {:value 1})}
+           (state-flow.core/flow "my-flow" (cljtest/match? "equals" 1 1)))))
 
   (fact "defines flow with binding and flow inside match?"
     (macroexpand-1 '(defflow my-flow {:init (constantly {:value 1
@@ -102,12 +102,12 @@
     => '(clojure.test/deftest
           my-flow
           (state-flow.core/run*
-            {:init (constantly {:map {:a 1 :b 2} :value 1})}
-            (state-flow.core/flow
-              "my-flow"
-              [value (state/gets :value)]
-              (cljtest/match? value 1)
-              (cljtest/match? (state/gets :map) {:b 2}))))))
+           {:init (constantly {:map {:a 1 :b 2} :value 1})}
+           (state-flow.core/flow
+            "my-flow"
+             [value (state/gets :value)]
+             (cljtest/match? value 1)
+             (cljtest/match? (state/gets :map) {:b 2}))))))
 
 (defflow my-flow {:init (constantly {:value 1
                                      :map {:a 1 :b 2}})}

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -76,24 +76,24 @@
         :value 0})
 
   (fact "flow without description fails at macro-expansion time"
-        (macroexpand `(state-flow/flow [original (state/gets :value)
-                                        :let [doubled (* 2 original)]]
-                                       (sf.state/modify #(assoc % :value doubled))))
-        => (throws IllegalArgumentException))
+    (macroexpand `(state-flow/flow [original (state/gets :value)
+                                    :let [doubled (* 2 original)]]
+                    (sf.state/modify #(assoc % :value doubled))))
+    => (throws IllegalArgumentException))
 
   (fact "flow with a `(str ..)` expr for the description is fine"
-      (macroexpand `(state-flow/flow (str "foo") [original (state/gets :value)
-                                                  :let [doubled (* 2 original)]]
-                                     (sf.state/modify #(assoc % :value doubled))))
-        => list?)
+    (macroexpand `(state-flow/flow (str "foo") [original (state/gets :value)
+                                                :let [doubled (* 2 original)]]
+                                   (sf.state/modify #(assoc % :value doubled))))
+    => list?)
 
   (fact "but flows with an expression that resolves to a string also aren't valid,
         due to resolution limitations at macro-expansion time"
-        (let [my-desc "trolololo"]
-          (macroexpand `(state-flow/flow ~'my-desc [original (state/gets :value)
-                                                    :let [doubled (* 2 original)]]
-                                         (sf.state/modify #(assoc % :value doubled)))))
-        => (throws IllegalArgumentException))
+    (let [my-desc "trolololo"]
+      (macroexpand `(state-flow/flow ~'my-desc [original (state/gets :value)
+                                                :let [doubled (* 2 original)]]
+                                     (sf.state/modify #(assoc % :value doubled)))))
+    => (throws IllegalArgumentException))
 
   (fact "nested-flow-with exception, returns exception and state before exception"
     (let [[left right] (state-flow/run bogus-flow {:value 0})]

--- a/test/state_flow/state_test.clj
+++ b/test/state_flow/state_test.clj
@@ -3,10 +3,10 @@
             [cats.core :as m]
             [cats.data :as d]
             [cats.monad.exception :as e]
+            [cats.monad.state :as state]
             [cats.protocols :as p]
             [midje.sweet :refer :all]
-            [state-flow.state :as sf.state]
-            [cats.monad.state :as state]))
+            [state-flow.state :as sf.state]))
 
 (def postincrement
   (m/mlet [x (sf.state/get)
@@ -22,8 +22,8 @@
   (m/mlet [x postincrement
            y postincrement
            z (sf.state/get)]
-          (m/return (fact "z is equal to initial state incremented by two"
-                      z => (+ x 2)))))
+    (m/return (fact "z is equal to initial state incremented by two"
+                z => (+ x 2)))))
 
 (state/run state-with-fact-check 0)
 


### PR DESCRIPTION
if you have logging enabled and a step fails with logging and retries, you get clobbered with 100 times of the same log. This PR changes the retry count to default to `3` instead of `100`.

Since this is a tiny change, I also took the liberty to add cljfmt and nsorg linters and run them.