### PR TITLE
wrap flow exprs with assertion to check expr is a flow

### DIFF
--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -41,13 +41,17 @@
            (or (= (first x) 'str)
                (= (first x) 'clojure.core/str)))))
 
+(defn wrap-with-assert-flow! [f]
+  `(do (assert (state/state? ~f) (str "Expected a flow but found a " (type ~f)))
+       ~f))
+
 (defmacro flow
   "Defines a flow"
   {:style/indent :defn}
   [description & flows]
   (when-not (string-expr? description)
     (throw (IllegalArgumentException. "The first argument of the flow must be a description string")))
-  (let [flows' (or flows
+  (let [flows' (or (map wrap-with-assert-flow! flows)
                    '[(state/swap identity)])]
     `(m/do-let
        (push-meta ~description)


### PR DESCRIPTION
before
```
user=> (clojure.test/run-tests 'state-flow.scratch)
19-12-17 19:58:45 mboi-tui INFO [state-flow.core:93] - Flow "my-flow" failed with exception
                        clojure.core/eval          core.clj: 3214
                                      ...
                           user/eval24183         REPL Input

                                      ...
                state-flow.state/reify/fn         state.clj:   35
            cats.protocols/eval12621/fn/G    protocols.cljc:   56
          clojure.core/-cache-protocol-fn  core_deftype.clj:  583
java.lang.IllegalArgumentException: No implementation of method: :-extract of protocol: #'cats.p
rotocols/Extract found for class: clojure.core$inc


ERROR in (my-flow) (core.clj:94)
Uncaught exception, not in assertion.
expected: nil
  actual: clojure.lang.ExceptionInfo: Flow "my-flow" failed with exception
{}
 at state_flow.core$run_BANG_.invokeStatic (core.clj:94)
    state_flow.core$run_BANG_.invoke (core.clj:85)
    state_flow.core$run_STAR_.invokeStatic (core.clj:110)
    state_flow.core$run_STAR_.invoke (core.clj:97)
    state_flow.scratch$fn__24174.invokeStatic (scratch.clj:12)

```
after
```
ERROR in (my-flow) (scratch.clj:12)
Uncaught exception, not in assertion.
expected: nil
  actual: java.lang.AssertionError: Assert failed: Expected a flow but found a class clojure.core$inc
(state-flow.state/state? inc)
 at state_flow.scratch$fn__24347$fn__24348.invoke (scratch.clj:12)
    cats.core$bind$fn__12966.invoke (core.cljc:96)
    state_flow.state$reify__20835$fn__20841.invoke (state.clj:40)
    cats.monad.state$run.invokeStatic (state.cljc:147)
    cats.monad.state$run.invoke (state.cljc:136)
    state_flow.core$run.invokeStatic (core.clj:87)
    state_flow.core$run.invoke (core.clj:83)
    state_flow.core$run_BANG_.invokeStatic (core.clj:92)
```

TODO: write a proper test :)