### PR TITLE
Add `testing` macro to cljtest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.0.5]
+- Add `state-flow.labs` namespace for experimental features
+- Add `state-flow.labs.cljtest/testing`
+
 ## [2.0.4]
 - update `times-to-try` default from `100` to `5` and `sleep-time` default from `10` to `200`
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "2.0.4"
+(defproject nubank/state-flow "2.0.5"
   :description "Postman-like integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}

--- a/src/state_flow/cljtest.clj
+++ b/src/state_flow/cljtest.clj
@@ -6,13 +6,6 @@
             [state-flow.core :as core]
             [state-flow.state :as state]))
 
-(defmacro testing [desc & body]
-  "state-flow's equivalent to clojure test's `testing`"
-  `(core/flow ~desc
-              [full-desc# (core/get-description)]
-              (state/wrap-fn #(do ~(with-meta `(ctest/testing ~desc ~@body)
-                                     (meta &form))))))
-
 (defn ^:private match-expr
   [desc value checker]
   (let [test-name (symbol (clojure.string/replace desc " " "-"))]

--- a/src/state_flow/cljtest.clj
+++ b/src/state_flow/cljtest.clj
@@ -6,6 +6,13 @@
             [state-flow.core :as core]
             [state-flow.state :as state]))
 
+(defmacro testing [desc & body]
+  "state-flow's equivalent to clojure test's `testing`"
+  `(core/flow ~desc
+              [full-desc# (core/get-description)]
+              (state/wrap-fn #(do ~(with-meta `(ctest/testing ~desc ~@body)
+                                     (meta &form))))))
+
 (defn ^:private match-expr
   [desc value checker]
   (let [test-name (symbol (clojure.string/replace desc " " "-"))]

--- a/src/state_flow/labs/cljtest.clj
+++ b/src/state_flow/labs/cljtest.clj
@@ -1,0 +1,11 @@
+(ns state-flow.labs.cljtest
+  (:require [state-flow.core :as core]
+            [state-flow.state :as state]
+            [clojure.test :as ctest]))
+
+(defmacro testing [desc & body]
+  "state-flow's equivalent to clojure test's `testing`"
+  `(core/flow ~desc
+              [full-desc# (core/get-description)]
+              (state/wrap-fn #(do ~(with-meta `(ctest/testing ~desc ~@body)
+                                     (meta &form))))))

--- a/test/state_flow/cljtest_test.clj
+++ b/test/state_flow/cljtest_test.clj
@@ -2,8 +2,9 @@
   (:require [cats.core :as m]
             [cats.data :as d]
             [cats.monad.state :as state]
-            [clojure.test :as ctest]
+            [clojure.test :as ctest :refer [is]]
             [matcher-combinators.matchers :as matchers]
+            [matcher-combinators.test]
             [midje.sweet :refer :all]
             [state-flow.cljtest :as cljtest :refer [defflow]]
             [state-flow.core :as state-flow :refer [flow]]
@@ -75,6 +76,25 @@
       => (d/pair [1 2 3]
                  {:value [1 2 3]
                   :meta  {:description []}}))))
+
+(defmacro tap [x]
+  `(let [res# ~x]
+     (clojure.pprint/pprint '~x)
+     (clojure.pprint/pprint res#)
+
+     res#))
+
+(facts "on `testing`"
+       (fact "works for failure cases"
+             (let [val {:value {:a 2 :b 5}}]
+               (state-flow/run (state-flow/flow "desc"
+                                 [v (state/gets :value)]
+                                 (cljtest/testing "contains with monadic left value"
+                                   (is (= {:a 1 :b 5} v))))
+                 val)
+               => (d/pair false
+                          {:value {:a 2 :b 5}
+                           :meta  {:description []}}))))
 
 (facts "defflow"
   (fact "defines flow with default parameters"

--- a/test/state_flow/cljtest_test.clj
+++ b/test/state_flow/cljtest_test.clj
@@ -77,18 +77,6 @@
                  {:value [1 2 3]
                   :meta  {:description []}}))))
 
-(facts "on `testing`"
-       (fact "works for failure cases"
-             (let [val {:value {:a 2 :b 5}}]
-               (state-flow/run (state-flow/flow "desc"
-                                 [v (state/gets :value)]
-                                 (cljtest/testing "contains with monadic left value"
-                                   (is (= {:a 1 :b 5} v))))
-                 val)
-               => (d/pair false
-                          {:value {:a 2 :b 5}
-                           :meta  {:description []}}))))
-
 (facts "defflow"
   (fact "defines flow with default parameters"
     (macroexpand-1 '(defflow my-flow (cljtest/match? "equals" 1 1)))

--- a/test/state_flow/cljtest_test.clj
+++ b/test/state_flow/cljtest_test.clj
@@ -77,13 +77,6 @@
                  {:value [1 2 3]
                   :meta  {:description []}}))))
 
-(defmacro tap [x]
-  `(let [res# ~x]
-     (clojure.pprint/pprint '~x)
-     (clojure.pprint/pprint res#)
-
-     res#))
-
 (facts "on `testing`"
        (fact "works for failure cases"
              (let [val {:value {:a 2 :b 5}}]

--- a/test/state_flow/labs/cljtest_test.clj
+++ b/test/state_flow/labs/cljtest_test.clj
@@ -1,0 +1,19 @@
+(ns state-flow.labs.cljtest-test
+  (:require [midje.sweet :refer [facts fact =>]]
+            [clojure.test :as ctest :refer [is]]
+            [state-flow.labs.cljtest :as labs.cljtest]
+            [cats.data :as d]
+            [state-flow.core :as state-flow]
+            [cats.monad.state :as state]))
+
+(facts "on `testing`"
+  (fact "works for failure cases"
+    (let [val {:value {:a 2 :b 5}}]
+      (state-flow/run (state-flow/flow "desc"
+                        [v (state/gets :value)]
+                        (labs.cljtest/testing "contains with monadic left value"
+                          (is (= {:a 1 :b 5} v))))
+        val)
+      => (d/pair false
+                 {:value {:a 2 :b 5}
+                  :meta  {:description []}}))))


### PR DESCRIPTION
It looks like it doesn't break anything (amount of fails when running the test is the same as before the PR), but the test output was confusing, so I'm not sure