### PR TITLE
Convert tests to use clojure.test

### DIFF
--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -50,7 +50,7 @@
   (when-not (string-expr? description)
      (throw (IllegalArgumentException. "The first argument to flow must be a description string")))
   (let [flows' (or flows
-                   '[(m/return nil)])]
+                   `[(m/return nil)])]
     `(m/do-let
       (push-meta ~description)
       [ret# (m/do-let ~@flows')]
@@ -64,7 +64,7 @@
   (state/run flow initial-state))
 
 (defn run!
-  "Like run, but prints a log and throws error when flow fails with an exception"
+  "Like run, but prints a log and throws an error when the flow fails with an exception"
   [flow initial-state]
   (let [result (run flow initial-state)]
     (when (e/failure? (first result))

--- a/src/state_flow/probe.clj
+++ b/src/state_flow/probe.clj
@@ -21,12 +21,12 @@
 
 (defn probe
   "evaluates state repeatedly with check-fn until check-fn succeeds or we try too many times"
+  ([state check-fn]
+   (probe state check-fn {:sleep-time default-sleep-time :times-to-try default-times-to-try}))
   ([state check-fn {:keys [sleep-time times-to-try]
                     :or   {sleep-time   default-sleep-time
                            times-to-try default-times-to-try}}]
    (m/mlet [world (state/get)
             :let [runs   (repeatedly #(do (Thread/sleep sleep-time) (state/eval state world)))
-                  result (retry times-to-try #(check-fn %) runs)]]
-     (state/return result)))
-  ([state check-fn]
-   (probe state check-fn {:sleep-time default-sleep-time :times-to-try default-times-to-try})))
+                  result (retry times-to-try check-fn runs)]]
+     (state/return result))))

--- a/src/state_flow/probe.clj
+++ b/src/state_flow/probe.clj
@@ -1,6 +1,5 @@
 (ns state-flow.probe
-  (:require [midje.sweet :as midje]
-            [cats.core :as m]
+  (:require [cats.core :as m]
             [state-flow.state :as state]))
 
 ;;

--- a/test/state_flow/cljtest_test.clj
+++ b/test/state_flow/cljtest_test.clj
@@ -142,6 +142,3 @@
   (is (match? {:value 1
                :map   {:a 1 :b 2}}
               (second ((:test (meta #'my-flow)))))))
-
-(comment
-  (t/run-tests))

--- a/test/state_flow/cljtest_test.clj
+++ b/test/state_flow/cljtest_test.clj
@@ -36,27 +36,27 @@
           (is (= {:a 2 :b 5} (:value state)))))
 
   (testing "failure case"
-    (let [{:keys [flow-res flow-state]}
+    (let [{:keys [flow-ret flow-state]}
           (th/run-flow (cljtest/match? "contains with monadic left value"
                                                       (state/gets :value)
                                                       (matchers/equals {:a 1 :b 5}))
                     {:value {:a 2 :b 5}})]
-      (is (= {:a 2 :b 5} flow-res))
+      (is (= {:a 2 :b 5} flow-ret))
       (is (= {:a 2 :b 5} (:value flow-state)))))
 
   (testing "add two with small delay"
     (let [state  {:value (atom 0)}
-          {:keys [flow-res]}
+          {:keys [flow-ret]}
           (th/run-flow
             (flow ""
               (th/delayed-add-two 100)
               (cljtest/match? "" get-value-state 2))
             state)]
-      (is (= 2 flow-res))))
+      (is (= 2 flow-ret))))
 
   (testing "we can tweak timeout and times to try"
     (let [state  {:value (atom 0)}
-          {:keys [report-data flow-res flow-state]}
+          {:keys [report-data flow-ret flow-state]}
           (th/run-flow
            (flow ""
              (th/delayed-add-two 100)
@@ -66,11 +66,11 @@
       (is (match? {:matcher-combinators.result/type :mismatch
                    :matcher-combinators.result/value {:expected 2 :actual 0}}
                   (-> report-data :actual :match-result)))
-      (is (= 0 flow-res))))
+      (is (= 0 flow-ret))))
 
   (testing "add two with too much delay (timeout)"
     (let [state  {:value (atom 0)}
-          {:keys [report-data flow-res flow-state]}
+          {:keys [report-data flow-ret flow-state]}
           (th/run-flow
            (flow ""
              (th/delayed-add-two 4000)
@@ -79,7 +79,7 @@
       (is (match? {:matcher-combinators.result/type :mismatch
                    :matcher-combinators.result/value {:expected 2 :actual 0}}
                   (-> report-data :actual :match-result)))
-      (is (= 0 flow-res))))
+      (is (= 0 flow-ret))))
 
   (testing "works with matcher combinators in any order"
     (let [val {:value [1 2 3]}

--- a/test/state_flow/cljtest_test.clj
+++ b/test/state_flow/cljtest_test.clj
@@ -1,10 +1,10 @@
 (ns state-flow.cljtest-test
   (:require [clojure.test :as t :refer [deftest testing is]]
+            [matcher-combinators.test] ;; loads match? assertions
+            [matcher-combinators.matchers :as matchers]
             [cats.core :as m]
             [cats.data :as d]
             [cats.monad.state :as state]
-            [matcher-combinators.test]
-            [matcher-combinators.matchers :as matchers]
             [state-flow.test-helpers :as th]
             [state-flow.cljtest :as cljtest :refer [defflow]]
             [state-flow.core :as state-flow :refer [flow]]

--- a/test/state_flow/cljtest_test.clj
+++ b/test/state_flow/cljtest_test.clj
@@ -1,6 +1,6 @@
 (ns state-flow.cljtest-test
   (:require [clojure.test :as t :refer [deftest testing is]]
-            [matcher-combinators.test] ;; loads match? assertions
+            [matcher-combinators.test :refer [match?]]
             [matcher-combinators.matchers :as matchers]
             [cats.core :as m]
             [cats.data :as d]

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -1,6 +1,6 @@
 (ns state-flow.core-test
   (:require [clojure.test :as t :refer [deftest testing is]]
-            [matcher-combinators.test] ;; loads match? assertions
+            [matcher-combinators.test :refer [match?]]
             [cats.core :as cats]
             [state-flow.test-helpers :as test-helpers]
             [state-flow.core :as state-flow :refer [flow]]

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :as t :refer [deftest testing is]]
             [cats.core :as m]
             [cats.monad.state :as state]
+            [matcher-combinators.test]
             [state-flow.test-helpers :as th]
             [state-flow.core :as state-flow]
             [state-flow.state :as sf.state]))

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -1,130 +1,129 @@
 (ns state-flow.core-test
-  (:require [cats.core :as m]
+  (:require [clojure.test :as t :refer [deftest testing is]]
+            [cats.core :as m]
             [cats.monad.state :as state]
-            [matcher-combinators.midje :refer [match]]
-            [midje.sweet :refer :all]
+            [state-flow.test-helpers :as th]
             [state-flow.core :as state-flow]
-            [state-flow.midje :as midje]
             [state-flow.state :as sf.state]))
 
-(defn double-key [k]
-  (state/swap (fn [w] (update w k #(* 2 %)))))
-
 (def bogus (state/state (fn [s] (throw (Exception. "My exception")))))
-(def increment-two-value
-  (state/swap (fn [s] (update s :value #(+ 2 %)))))
+(def add-two
+  (state/swap (fn [s] (update s :value + 2))))
 
 (def nested-flow
   (state-flow/flow "root"
-    (state-flow/flow "child1" increment-two-value)
-    (state-flow/flow "child2" increment-two-value)
-    (midje/verify "value incremented by 4"
-                  (state/gets #(-> % :value)) 4)))
+    (state-flow/flow "child1" add-two)
+    (state-flow/flow "child2" add-two)))
 
 (def flow-with-bindings
   (state-flow/flow "root"
     [original (state/gets :value)
      :let [doubled (* 2 original)]]
-    (sf.state/modify #(assoc % :value doubled))
-    (midje/verify "value is doubled"
-                  (state/gets #(-> % :value)) doubled)))
+    (sf.state/modify #(assoc % :value doubled))))
 
 (def bogus-flow
   (state-flow/flow "root"
-    (state-flow/flow "child1" increment-two-value)
-    (state-flow/flow "child2" bogus increment-two-value)))
+    (state-flow/flow "child1" add-two)
+    (state-flow/flow "child2" bogus add-two)))
 
 (def empty-flow
   (state-flow/flow "empty"))
 
-(fact "on push-meta"
-  (state/exec (m/>> (#'state-flow/push-meta "mydesc")
-                    (#'state-flow/push-meta "mydesc2")) {}) => {:meta {:description [["mydesc"]
-                                                                                     ["mydesc" "mydesc2"]]}})
+(deftest push-meta
+  (is (= {:meta {:description [["mydesc"]
+                               ["mydesc" "mydesc2"]]}}
+         (state/exec (m/>> (#'state-flow/push-meta "mydesc")
+                           (#'state-flow/push-meta "mydesc2")) {}))))
 
-(facts "on run flow"
-  (fact "run flow of single step"
-    (state/exec (state-flow/flow "single step" increment-two-value) {:value 0}) => {:meta  {:description [["single step"]
-                                                                                                          []]}
-                                                                                    :value 2})
-  (fact "flow with two steps"
-    (second (state-flow/run (state-flow/flow "two step flow"
-                              (state-flow/flow "first step" increment-two-value)
-                              (state-flow/flow "second step" increment-two-value))
-              {:value 0})) => {:meta                                         {:description [["two step flow"]
-                                                                                            ["two step flow" "first step"]
-                                                                                            ["two step flow"]
-                                                                                            ["two step flow" "second step"]
-                                                                                            ["two step flow"]
-                                                                                            []]} :value 4})
+(deftest run-flow
+  (testing "with single step"
+    (is (= {:meta  {:description [["single step"]
+                                  []]}
+            :value 2}
+           (state/exec (state-flow/flow "single step" add-two) {:value 0}))))
+  (testing "with two steps"
+    (is (= {:meta {:description [["two step flow"]
+                                 ["two step flow" "first step"]
+                                 ["two step flow"]
+                                 ["two step flow" "second step"]
+                                 ["two step flow"]
+                                 []]}
+            :value 4}
+           (second (state-flow/run (state-flow/flow "two step flow"
+                                     (state-flow/flow "first step" add-two)
+                                     (state-flow/flow "second step" add-two))
+                     {:value 0})))))
 
-  (fact "empty flow"
-    (state-flow/run empty-flow {}) => irrelevant)
+  (testing "empty flow runs without exception"
+    (is (nil? (first (state-flow/run empty-flow {})))))
 
-  (fact "flow without description fails at macro-expansion time"
-        (try
-          (macroexpand `(state-flow/flow (sf.state/return {})))
-          (catch clojure.lang.Compiler$CompilerException e
-            (.. e getCause getMessage)))
-        => #"first argument .* must be .* description string")
+  (testing "flow without description fails at macro-expansion time"
+    (is (re-find #"first argument .* must be .* description string"
+                 (try
+                   (macroexpand `(state-flow/flow (sf.state/return {})))
+                   (catch clojure.lang.Compiler$CompilerException e
+                     (.. e getCause getMessage))))))
 
-  (fact "flow with a `(str ..)` expr for the description is fine"
-    (macroexpand `(state-flow/flow (str "foo") [original (state/gets :value)
-                                                :let [doubled (* 2 original)]]
-                    (sf.state/modify #(assoc % :value doubled))))
-    => list?)
+  (testing "flow with a `(str ..)` expr for the description is fine"
+    (is (macroexpand `(state-flow/flow (str "foo") [original (state/gets :value)
+                                                    :let [doubled (* 2 original)]]
+                        (sf.state/modify #(assoc % :value doubled))))))
 
-  (fact "but flows with an expression that resolves to a string also aren't valid,
-        due to resolution limitations at macro-expansion time"
-        (let [my-desc "trolololo"]
-          (try
-            (macroexpand `(state-flow/flow ~'my-desc [original (state/gets :value)
-                                                      :let [doubled (* 2 original)]]
-                            (sf.state/modify #(assoc % :value doubled))))
-            (catch clojure.lang.Compiler$CompilerException e
-              (.. e getCause getMessage))))
-        => #"first argument .* must be .* description string")
+  (testing "but flows with an expression that resolves to a string also aren't valid,
+            due to resolution limitations at macro-expansion time"
+    (is (re-find #"first argument .* must be .* description string"
+                 (let [my-desc "trolololo"]
+                   (try
+                     (macroexpand `(state-flow/flow ~'my-desc [original (state/gets :value)
+                                                               :let [doubled (* 2 original)]]
+                                     (sf.state/modify #(assoc % :value doubled))))
+                     (catch clojure.lang.Compiler$CompilerException e
+                       (.. e getCause getMessage)))))))
 
-  (fact "nested-flow-with exception, returns exception and state before exception"
+  (testing "nested-flow-with exception, returns exception and state before exception"
     (let [[left right] (state-flow/run bogus-flow {:value 0})]
-      @left => (throws Exception "My exception")
-      right => {:meta  {:description [["root"]
-                                      ["root" "child1"]
-                                      ["root"]
-                                      ["root" "child2"]]}
-                :value 2}))
+      (is (thrown-with-msg? Exception #"My exception" @left))
+      (is (= {:meta  {:description [["root"]
+                                    ["root" "child1"]
+                                    ["root"]
+                                    ["root" "child2"]]}
+              :value 2}
+             right))))
 
-  (fact "flow allows do-let style binding"
-    (second (state-flow/run flow-with-bindings {:value 2}))
-    => (match {:value 4}))
+  (testing "flow allows do-let style binding"
+    (is (match?
+         {:value 4}
+         (second (state-flow/run flow-with-bindings {:value 2})))))
 
-  (fact "run! throws exception"
-    (with-out-str
-      (state-flow/run! bogus-flow {:value 0})) => (throws Exception)))
+  (testing "run! throws exception"
+    (is (thrown? Exception (th/run-flow bogus-flow {:value 0})))))
 
-(facts state-flow/run*
+(deftest state-flow-run*
 
-  (fact "flow with initializer"
-    (second (state-flow/run* {:init (constantly {:value 0})} nested-flow))
-    => (match {:value 4}))
+  (testing "flow with initializer"
+    (is (match? {:value 4}
+                (second (state-flow/run* {:init (constantly {:value 0})} nested-flow)))))
 
-  (fact "flow with cleanup"
-    (-> (state-flow/run* {:init    (constantly {:value 0
-                                                :atom  (atom 1)})
-                          :cleanup #(reset! (:atom %) 0)}
-                         nested-flow)
-        second
-        :atom
-        deref)
-    => 0)
+  (testing "flow with cleanup"
+    (is (zero?
+         (-> (state-flow/run* {:init    (constantly {:value 0
+                                                     :atom  (atom 1)})
+                               :cleanup #(reset! (:atom %) 0)}
+               nested-flow)
+             second
+             :atom
+             deref))))
 
-  (fact "flow with custom runner"
-    (second (state-flow/run* {:init   (constantly {:value 0})
-                             :runner (fn [flow state]
-                                       [nil (state/exec flow state)])}
-             nested-flow))
-    => (match {:value 4})))
+  (testing "flow with custom runner"
+    (is (match? {:value 4}
+                (second (state-flow/run* {:init   (constantly {:value 0})
+                                          :runner (fn [flow state]
+                                                    [nil (state/exec flow state)])}
+                          nested-flow))))))
 
-(facts "on as-step-fn"
-  (let [increment-two-step (state-flow/as-step-fn (state/swap #(+ 2 %)))]
-    (increment-two-step 1) => 3))
+(deftest as-step-fn
+  (let [add-two-step (state-flow/as-step-fn (state/swap #(+ 2 %)))]
+    (is (= 3 (add-two-step 1)))))
+
+(comment
+  (t/run-tests))

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -1,8 +1,8 @@
 (ns state-flow.core-test
   (:require [clojure.test :as t :refer [deftest testing is]]
+            [matcher-combinators.test] ;; loads match? assertions
             [cats.core :as m]
             [cats.monad.state :as state]
-            [matcher-combinators.test]
             [state-flow.test-helpers :as th]
             [state-flow.core :as state-flow]
             [state-flow.state :as sf.state]))

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -127,6 +127,3 @@
 (deftest as-step-fn
   (let [add-two-fn (state-flow/as-step-fn (state/modify #(+ 2 %)))]
     (is (= 3 (add-two-fn 1)))))
-
-(comment
-  (t/run-tests))

--- a/test/state_flow/labs/cljtest_test.clj
+++ b/test/state_flow/labs/cljtest_test.clj
@@ -6,7 +6,7 @@
             [state-flow.core :as state-flow]
             [state-flow.state :as state]))
 
-(deftest test-testing
+(deftest testing-macro
   (testing "works for failure cases"
     (let [{:keys [flow-res flow-state]}
           (th/run-flow (state-flow/flow "desc"

--- a/test/state_flow/labs/cljtest_test.clj
+++ b/test/state_flow/labs/cljtest_test.clj
@@ -1,6 +1,6 @@
 (ns state-flow.labs.cljtest-test
   (:require [clojure.test :as t :refer [deftest testing is]]
-            [matcher-combinators.test]
+            [matcher-combinators.test] ;; loads match? assertions
             [state-flow.test-helpers :as th]
             [state-flow.labs.cljtest :as labs.cljtest]
             [state-flow.core :as state-flow]

--- a/test/state_flow/labs/cljtest_test.clj
+++ b/test/state_flow/labs/cljtest_test.clj
@@ -1,6 +1,6 @@
 (ns state-flow.labs.cljtest-test
   (:require [clojure.test :as t :refer [deftest testing is]]
-            [matcher-combinators.test] ;; loads match? assertions
+            [matcher-combinators.test :refer [match?]]
             [state-flow.test-helpers :as th]
             [state-flow.labs.cljtest :as labs.cljtest]
             [state-flow.core :as state-flow]

--- a/test/state_flow/labs/cljtest_test.clj
+++ b/test/state_flow/labs/cljtest_test.clj
@@ -1,20 +1,19 @@
 (ns state-flow.labs.cljtest-test
-  (:require [midje.sweet :refer [facts fact =>]]
-            [clojure.test :as ctest :refer [is]]
-            [matcher-combinators.midje :refer [match]]
+  (:require [clojure.test :as t :refer [deftest testing is]]
+            [matcher-combinators.test]
+            [state-flow.test-helpers :as th]
             [state-flow.labs.cljtest :as labs.cljtest]
-            [cats.data :as d]
             [state-flow.core :as state-flow]
-            [cats.monad.state :as state]))
+            [state-flow.state :as state]))
 
-(facts "on `testing`"
-  (fact "works for failure cases"
-    (let [val {:value {:a 2 :b 5}}
-          [ret state]
-          (state-flow/run (state-flow/flow "desc"
-                            [v (state/gets :value)]
-                            (labs.cljtest/testing "contains with monadic left value"
-                              (is (= {:a 1 :b 5} v))))
-            val)]
-      ret => false
-      state => (match {:value {:a 2 :b 5}}))))
+(deftest test-testing
+  (testing "works for failure cases"
+    (let [{:keys [flow-res flow-state]}
+          (th/run-flow (state-flow/flow "desc"
+                         [v (state/gets :value)]
+                         (labs.cljtest/testing "contains with monadic left value"
+                           (is (= {:a 1 :b 5} v))))
+                       {:value {:a 2 :b 5}})]
+      (is (false? flow-res))
+      (is (match? {:value {:a 2 :b 5}}
+                  flow-state)))))

--- a/test/state_flow/labs/cljtest_test.clj
+++ b/test/state_flow/labs/cljtest_test.clj
@@ -8,12 +8,12 @@
 
 (deftest testing-macro
   (testing "works for failure cases"
-    (let [{:keys [flow-res flow-state]}
+    (let [{:keys [flow-ret flow-state]}
           (th/run-flow (state-flow/flow "desc"
                          [v (state/gets :value)]
                          (labs.cljtest/testing "contains with monadic left value"
                            (is (= {:a 1 :b 5} v))))
                        {:value {:a 2 :b 5}})]
-      (is (false? flow-res))
+      (is (false? flow-ret))
       (is (match? {:value {:a 2 :b 5}}
                   flow-state)))))

--- a/test/state_flow/midje_test.clj
+++ b/test/state_flow/midje_test.clj
@@ -37,6 +37,3 @@
                                         (sf.state/get) (contains {:a 2}) {}) val)
          (state/run (midje/verify-probe "just with monadic left value"
                                         (sf.state/get) (just {:a 2 :b 5}) {}) val)))))
-
-(comment
-  (t/run-tests))

--- a/test/state_flow/midje_test.clj
+++ b/test/state_flow/midje_test.clj
@@ -1,8 +1,8 @@
 (ns state-flow.midje-test
   (:require [clojure.test :as t :refer [deftest testing is]]
+            [matcher-combinators.test] ;; loads match? assertions
             [cats.data :as d]
             [cats.monad.state :as state]
-            [matcher-combinators.test]
             [midje.sweet :refer [contains just]]
             [state-flow.core :as state-flow]
             [state-flow.midje :as midje]

--- a/test/state_flow/midje_test.clj
+++ b/test/state_flow/midje_test.clj
@@ -11,7 +11,7 @@
 (facts "on verify"
 
   (fact "add two to state 1, result is 3, doesn't change world"
-    (let [[ret state] (state-flow/run (midje/verify "description" test-helpers/increment-two 3) {:value 1})]
+    (let [[ret state] (state-flow/run (midje/verify "description" test-helpers/add-two 3) {:value 1})]
       ret => 3
       state => {:value 1 :meta {:description [["description"] []]}}))
 
@@ -21,13 +21,13 @@
 
   (fact "add two with small delay"
     (def world {:value (atom 0)})
-    (state-flow/run (test-helpers/delayed-increment-two 100) world) => (d/pair nil world)
+    (state-flow/run (test-helpers/delayed-add-two 100) world) => (d/pair nil world)
     (state-flow/run (midje/verify "description" test-helpers/get-value-state 2) world)
     => (d/pair 2 (merge world {:meta {:description [["description"] []]}})))
 
   (fact "add two with too much delay"
     (def world {:value (atom 0)})
-    (state-flow/run (test-helpers/delayed-increment-two 4000) world)
+    (state-flow/run (test-helpers/delayed-add-two 4000) world)
     (state-flow/run (midje/verify "description" test-helpers/get-value-state 0) world))
 
   (fact "extended equality works"

--- a/test/state_flow/midje_test.clj
+++ b/test/state_flow/midje_test.clj
@@ -1,38 +1,42 @@
 (ns state-flow.midje-test
-  (:require [cats.core :as m]
+  (:require [clojure.test :as t :refer [deftest testing is]]
             [cats.data :as d]
             [cats.monad.state :as state]
-            [midje.sweet :refer :all]
+            [matcher-combinators.test]
+            [midje.sweet :refer [contains just]]
             [state-flow.core :as state-flow]
             [state-flow.midje :as midje]
             [state-flow.state :as sf.state]
             [state-flow.test-helpers :as test-helpers]))
 
-(facts "on verify"
-
-  (fact "add two to state 1, result is 3, doesn't change world"
+(deftest verify
+  (testing "add two to state 1, result is 3, doesn't change world"
     (let [[ret state] (state-flow/run (midje/verify "description" test-helpers/add-two 3) {:value 1})]
-      ret => 3
-      state => {:value 1 :meta {:description [["description"] []]}}))
+      (is (= 3 ret))
+      (is (match? {:value 1 :meta {:description [["description"] []]}}
+                  state))))
 
-  (fact "works with non-state values"
-    (state-flow/run (midje/verify "description" 3 3) {})
-    => (d/pair 3 {:meta {:description [["description"] []]}}))
+  (testing "works with non-state values"
+    (is (= (d/pair 3 {:meta {:description [["description"] []]}})
+           (state-flow/run (midje/verify "description" 3 3) {}))))
 
-  (fact "add two with small delay"
-    (def world {:value (atom 0)})
-    (state-flow/run (test-helpers/delayed-add-two 100) world) => (d/pair nil world)
-    (state-flow/run (midje/verify "description" test-helpers/get-value-state 2) world)
-    => (d/pair 2 (merge world {:meta {:description [["description"] []]}})))
+  (testing "add two with small delay"
+    (let [world {:value (atom 0)}]
+      (is (nil? (first (state-flow/run (test-helpers/delayed-add-two 100) world))))
+      (is (= 2 (first (state-flow/run (midje/verify "description" test-helpers/get-value-state 2) world))))))
 
-  (fact "add two with too much delay"
-    (def world {:value (atom 0)})
-    (state-flow/run (test-helpers/delayed-add-two 4000) world)
-    (state-flow/run (midje/verify "description" test-helpers/get-value-state 0) world))
+  (testing "add two with too much delay"
+    (let [world {:value (atom 0)}]
+      (is (nil? (first (state-flow/run (test-helpers/delayed-add-two 4000) world))))
+      (is (= 0 (first (state-flow/run (midje/verify "description" test-helpers/get-value-state 0) world))))))
 
-  (fact "extended equality works"
+  (testing "extended equality"
     (let [val {:a 2 :b 5}]
-      (state/run (midje/verify-probe "contains with monadic left value"
-                                     (sf.state/get) (contains {:a 2}) {}) val) => (d/pair val val)
-      (state/run (midje/verify-probe "just with monadic left value"
-                                     (sf.state/get) (just {:a 2 :b 5}) {}) val) => (d/pair val val))))
+      (= (d/pair val val)
+         (state/run (midje/verify-probe "contains with monadic left value"
+                                        (sf.state/get) (contains {:a 2}) {}) val)
+         (state/run (midje/verify-probe "just with monadic left value"
+                                        (sf.state/get) (just {:a 2 :b 5}) {}) val)))))
+
+(comment
+  (t/run-tests))

--- a/test/state_flow/midje_test.clj
+++ b/test/state_flow/midje_test.clj
@@ -1,6 +1,6 @@
 (ns state-flow.midje-test
   (:require [clojure.test :as t :refer [deftest testing is]]
-            [matcher-combinators.test] ;; loads match? assertions
+            [matcher-combinators.test :refer [match?]]
             [cats.data :as d]
             [cats.monad.state :as state]
             [midje.sweet :refer [contains just]]

--- a/test/state_flow/probe_test.clj
+++ b/test/state_flow/probe_test.clj
@@ -21,6 +21,3 @@
                  (state-flow/run (test-helpers/delayed-add-two 4000) state)))
           (is (= (d/pair [false 0] state)
                  (state-flow/run (probe/probe test-helpers/get-value-state #(= 2 %)) state))))))
-
-(comment
-  (t/run-tests))

--- a/test/state_flow/probe_test.clj
+++ b/test/state_flow/probe_test.clj
@@ -8,17 +8,17 @@
 (deftest test-probe
   (testing "add two to state 1, result is 3, doesn't change world"
     (is (= [true 3]
-           (first (state-flow/run (probe/probe test-helpers/increment-two #(= % 3)) {:value 1})))))
+           (first (state-flow/run (probe/probe test-helpers/add-two #(= % 3)) {:value 1})))))
   (testing "add two with small delay"
     (let [state {:value (atom 0)}]
       (is (= (d/pair nil state))
-          (state-flow/run (test-helpers/delayed-increment-two 100) state))
+          (state-flow/run (test-helpers/delayed-add-two 100) state))
       (is (= (d/pair [true 2] state)
              (state-flow/run (probe/probe test-helpers/get-value-state #(= 2 %)) state)))))
   (testing "add two with too much delay"
         (let [state {:value (atom 0)}]
           (is (= (d/pair nil state)
-                 (state-flow/run (test-helpers/delayed-increment-two 4000) state)))
+                 (state-flow/run (test-helpers/delayed-add-two 4000) state)))
           (is (= (d/pair [false 0] state)
                  (state-flow/run (probe/probe test-helpers/get-value-state #(= 2 %)) state))))))
 

--- a/test/state_flow/state_test.clj
+++ b/test/state_flow/state_test.clj
@@ -6,7 +6,7 @@
             [cats.monad.state :as state]
             [state-flow.state :as sf.state]))
 
-(deftest test-state
+(deftest state
   (let [increment-state       (m/mlet [x (sf.state/get)
                                        _ (sf.state/put (inc x))]
                                       (m/return x))

--- a/test/state_flow/state_test.clj
+++ b/test/state_flow/state_test.clj
@@ -42,5 +42,4 @@
         (is (= 8 state))))))
 
 (comment
-  )
-(t/run-tests)
+  (t/run-tests))

--- a/test/state_flow/state_test.clj
+++ b/test/state_flow/state_test.clj
@@ -1,38 +1,46 @@
 (ns state-flow.state-test
-  (:require [cats.context :as ctx]
+  (:require [clojure.test :as t :refer [deftest testing is]]
             [cats.core :as m]
             [cats.data :as d]
             [cats.monad.exception :as e]
             [cats.monad.state :as state]
-            [cats.protocols :as p]
-            [midje.sweet :refer :all]
+            [midje.sweet :as midje]
             [state-flow.state :as sf.state]))
 
-(def postincrement
-  (m/mlet [x (sf.state/get)
-           _ (sf.state/put (+ x 1))]
-    (m/return x)))
+(deftest test-state
+  (let [increment-state       (m/mlet [x (sf.state/get)
+                                       _ (sf.state/put (inc x))]
+                                      (m/return x))
+        double-state          (sf.state/modify #(* 2 %))
+        state-with-fact-check (m/mlet [x increment-state
+                                       y increment-state
+                                       z (sf.state/get)]
+                                      (m/return (midje/fact "z is equal to initial state incremented by two"
+                                                            z => (+ x 2))))
+        state-with-assertion  (m/mlet [x increment-state
+                                       y increment-state
+                                       z (sf.state/get)]
+                                      (m/return (is (= z (+ x 2)))))]
+    (testing "modify state with get and put"
+      (is (= (d/pair 2 3)
+             (state/run increment-state 2))))
+    (testing "modify state with modify"
+      (is (= (d/pair 2 4)
+             (state/run double-state 2))))
+    (testing "state with fact check"
+      (is (= (d/pair true 2)
+             (state/run state-with-fact-check 0))))
+    (testing "state with clojure test assertion"
+      (is (= (d/pair true 2)
+             (state/run state-with-assertion 0))))
+    (testing "state with an exception"
+      (let [[res state] (state/run (m/>> double-state
+                                         double-state
+                                         (sf.state/modify (fn [s] (throw (Exception. "My exception"))))
+                                         double-state) 2)]
+        (is (e/failure? res))
+        (is (= 8 state))))))
 
-(def double-state (sf.state/modify #(* 2 %)))
-
-(fact "postincrement"
-  (state/run postincrement 1) => (d/pair 1 2))
-
-(def state-with-fact-check
-  (m/mlet [x postincrement
-           y postincrement
-           z (sf.state/get)]
-    (m/return (fact "z is equal to initial state incremented by two"
-                z => (+ x 2)))))
-
-(state/run state-with-fact-check 0)
-
-(def will-fail
-  (m/>> double-state
-        double-state
-        (sf.state/modify (fn [s] (throw (Exception. "My exception"))))
-        double-state))
-
-(fact "Error short-circuits execution"
-  (state/run will-fail 2) => (fn [[l r]] (and (e/failure? l)
-                                              (= r 8))))
+(comment
+  )
+(t/run-tests)

--- a/test/state_flow/state_test.clj
+++ b/test/state_flow/state_test.clj
@@ -4,35 +4,19 @@
             [cats.data :as d]
             [cats.monad.exception :as e]
             [cats.monad.state :as state]
-            [midje.sweet :as midje]
             [state-flow.state :as sf.state]))
 
 (deftest test-state
   (let [increment-state       (m/mlet [x (sf.state/get)
                                        _ (sf.state/put (inc x))]
                                       (m/return x))
-        double-state          (sf.state/modify #(* 2 %))
-        state-with-fact-check (m/mlet [x increment-state
-                                       y increment-state
-                                       z (sf.state/get)]
-                                      (m/return (midje/fact "z is equal to initial state incremented by two"
-                                                            z => (+ x 2))))
-        state-with-assertion  (m/mlet [x increment-state
-                                       y increment-state
-                                       z (sf.state/get)]
-                                      (m/return (is (= z (+ x 2)))))]
+        double-state          (sf.state/modify #(* 2 %))]
     (testing "modify state with get and put"
       (is (= (d/pair 2 3)
              (state/run increment-state 2))))
     (testing "modify state with modify"
       (is (= (d/pair 2 4)
              (state/run double-state 2))))
-    (testing "state with fact check"
-      (is (= (d/pair true 2)
-             (state/run state-with-fact-check 0))))
-    (testing "state with clojure test assertion"
-      (is (= (d/pair true 2)
-             (state/run state-with-assertion 0))))
     (testing "state with an exception"
       (let [[res state] (state/run (m/>> double-state
                                          double-state

--- a/test/state_flow/state_test.clj
+++ b/test/state_flow/state_test.clj
@@ -24,6 +24,3 @@
                                          double-state) 2)]
         (is (e/failure? res))
         (is (= 8 state))))))
-
-(comment
-  (t/run-tests))

--- a/test/state_flow/test_helpers.clj
+++ b/test/state_flow/test_helpers.clj
@@ -8,14 +8,13 @@
 (def get-value-state (state/gets get-value))
 
 (def increment-two
-  (m/mlet [world (sf.state/get)]
-    (m/return (+ 2 (-> world :value)))))
+  (m/mlet [state (sf.state/get)]
+    (m/return (+ 2 (-> state :value)))))
 
 (defn delayed-increment-two
   [delay-ms]
-  "Changes world in the future"
-  (state/state (fn [world]
+  "Changes state in the future"
+  (state/state (fn [state]
                  (future (do (Thread/sleep delay-ms)
-                             (swap! (:value world) + 2)))
-                 (d/pair nil world))))
-
+                             (swap! (:value state) + 2)))
+                 (d/pair nil state))))

--- a/test/state_flow/test_helpers.clj
+++ b/test/state_flow/test_helpers.clj
@@ -1,17 +1,19 @@
 (ns state-flow.test-helpers
-  (:require [cats.core :as m]
+  (:require [clojure.java.io :as io]
+            [cats.core :as m]
             [cats.data :as d]
             [cats.monad.state :as state]
-            [state-flow.state :as sf.state]))
+            [state-flow.state :as sf.state])
+  (:import (java.io File)))
 
 (def get-value (comp deref :value))
 (def get-value-state (state/gets get-value))
 
-(def increment-two
+(def add-two
   (m/mlet [state (sf.state/get)]
     (m/return (+ 2 (-> state :value)))))
 
-(defn delayed-increment-two
+(defn delayed-add-two
   [delay-ms]
   "Changes state in the future"
   (state/state (fn [state]
@@ -22,9 +24,10 @@
 (defmacro run-flow [flow state]
   `(let [report-data# (atom nil)
          res#         (with-redefs [clojure.test/do-report (fn [data#] (reset! report-data# data#))]
-                        (state-flow/run
-                          ~flow
-                          ~state))]
+                        (binding [*out* (io/writer (File/createTempFile "test" "log"))]
+                          (state-flow/run!
+                           ~flow
+                           ~state)))]
      {:report-data (->> (deref report-data#)
                         ;; NOTE: :matcher-combinators.result/value is a Mismatch object, which is
                         ;; a defrecord, so equality on a map won't pass, hence pouring it into a map

--- a/test/state_flow/test_helpers.clj
+++ b/test/state_flow/test_helpers.clj
@@ -18,3 +18,20 @@
                  (future (do (Thread/sleep delay-ms)
                              (swap! (:value state) + 2)))
                  (d/pair nil state))))
+
+(defmacro run-flow [flow state]
+  `(let [report-data# (atom nil)
+         res#         (with-redefs [clojure.test/do-report (fn [data#] (reset! report-data# data#))]
+                        (state-flow/run
+                          ~flow
+                          ~state))]
+     {:report-data (->> (deref report-data#)
+                        ;; NOTE: :matcher-combinators.result/value is a Mismatch object, which is
+                        ;; a defrecord, so equality on a map won't pass, hence pouring it into a map
+                        ;; to facilitate equality checks.
+                        (clojure.walk/postwalk (fn [node#]
+                                                 (if (instance? matcher_combinators.model.Mismatch node#)
+                                                   (into {} node#)
+                                                   node#))))
+      :flow-res    (first res#)
+      :flow-state  (second res#)}))

--- a/test/state_flow/test_helpers.clj
+++ b/test/state_flow/test_helpers.clj
@@ -1,10 +1,9 @@
 (ns state-flow.test-helpers
-  (:require [clojure.java.io :as io]
-            [cats.core :as m]
+  (:require [cats.core :as m]
             [cats.data :as d]
             [cats.monad.state :as state]
-            [state-flow.state :as sf.state])
-  (:import (java.io File)))
+            [state-flow.core]
+            [state-flow.state :as sf.state]))
 
 (def get-value (comp deref :value))
 (def get-value-state (state/gets get-value))
@@ -21,11 +20,14 @@
                              (swap! (:value state) + 2)))
                  (d/pair nil state))))
 
-(defmacro run-flow [flow state]
+(defmacro run-flow
+  "Same as state-flow.core/run! except does not report exceptions to *out* or test results from
+  within the flow."
+  [flow state]
   `(let [report-data# (atom nil)
          res#         (with-redefs [clojure.test/do-report (fn [data#] (reset! report-data# data#))]
-                        (binding [*out* (io/writer (File/createTempFile "test" "log"))]
-                          (state-flow/run!
+                        (binding [*out* (clojure.java.io/writer (java.io.File/createTempFile "test" "log"))]
+                          (state-flow.core/run!
                            ~flow
                            ~state)))]
      {:report-data (->> (deref report-data#)
@@ -36,5 +38,5 @@
                                                  (if (instance? matcher_combinators.model.Mismatch node#)
                                                    (into {} node#)
                                                    node#))))
-      :flow-res    (first res#)
+      :flow-ret    (first res#)
       :flow-state  (second res#)}))


### PR DESCRIPTION
This PR updates all tests to use clojure.test, and also introduces a run-flow! macro to support testing flows that include failing tests without reporting those failures (but still being able to make assertions about the expected failures).