### PR TITLE
add line numbers of flows to descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [DEV]
+- Add flow declaration line numbers to failure output
+
 ## [2.1.2]
 - Added state-flow.core/top-level-description fn
   - mostly for tooling built on top of state-flow


### PR DESCRIPTION
This is an alternate implementation of #35 based on feedback from @sovelten and @philomates.

This test code:

```clojure
(ns state-flow.lines-test
  (:require [state-flow.cljtest :refer [match?]]
            [state-flow.core :as state-flow]
            [state-flow.state :as state]))

(def increment-value-by-two
  (state/modify (fn [s] (update s :value + 2))))

(def failed-validate
  (state-flow/flow "inner validate"
    (match? "value incremented by 3"
            (state/gets #(-> % :value)) 3)))

(def nested-flow
  (state-flow/flow "root"
    (state-flow/flow "child1" increment-value-by-two)
    (state-flow/flow "child2" increment-value-by-two)
    failed-validate
    (match? "value incremented by 3"
            (state/gets #(-> % :value)) 3)))

(state-flow/run nested-flow {:value 0})
```

produces this ouptut:

```
FAIL in () (lines_test.clj:11)
root (line 15) -> inner validate (line 10) -> value incremented by 3
expected: (match? 3 extracted-value__14794__auto__)
  actual: (mismatch 3 4)


FAIL in () (lines_test.clj:19)
root (line 15) -> value incremented by 3
expected: (match? 3 extracted-value__14794__auto__)
  actual: (mismatch 3 4)
```