### PR TITLE
get description from meta (not :meta) in run! fn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Changelog
 
+## DEV
+- Added state-flow.core/top-level-description fn
+  - mostly for tooling built on top of state-flow
+
 ## [2.1.1]
 - Moved flow descriptions to the State object's meta
 
 ## [2.1.0]
 - Moved probe to its own namespace
-- Changed push-meta and pop-meta so that execution descriptions are logged
+- Changed push-meta and pop-meta so that execution descriptions are logged (internal)
 
 ## [2.0.5]
 - Add `state-flow.labs` namespace for experimental features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
-## DEV
+## [2.1.2]
 - Added state-flow.core/top-level-description fn
   - mostly for tooling built on top of state-flow
+- Removed state-flow.core/get-description
+  - This is for internal use, but if you happen to have been using it, you can
+    use state-flow.core/current-description instead.
 
 ## [2.1.1]
 - Moved flow descriptions to the State object's meta

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "2.1.1"
+(defproject nubank/state-flow "2.1.2"
   :description "Postman-like integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}

--- a/src/state_flow/cljtest.clj
+++ b/src/state_flow/cljtest.clj
@@ -31,7 +31,7 @@
   (let [the-meta (meta &form)
         params   (if (map? (first forms)) (first forms) {})]
     `(core/flow ~desc
-       [full-desc# (core/get-description)]
+       [full-desc# (core/current-description)]
        (if (state/state? ~value)
          (m/mlet [extracted-value# (match-probe ~value ~checker ~params)]
            (state/wrap-fn #(do (match+meta full-desc# extracted-value# ~checker ~the-meta)

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -56,6 +56,14 @@
            (or (= (first x) 'str)
                (= (first x) 'clojure.core/str)))))
 
+(defn current-description
+  "Returns a flow that returns the description as of the point of execution.
+
+  For internal use. Subject to change."
+  []
+  (m/mlet [desc-list (state/gets description-stack)]
+          (m/return (format-description desc-list))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Public API
 
@@ -64,14 +72,6 @@
   stringified symbol passed to defflow)."
   [s]
   (-> s meta :top-level-description))
-
-(defn current-description
-  "Returns a flow that returns the description as of the point of execution.
-
-  For internal use. Subject to change."
-  []
-  (m/mlet [desc-list (state/gets description-stack)]
-    (m/return (format-description desc-list))))
 
 (defmacro flow
   "Defines a flow"

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -43,12 +43,21 @@
    (fn [s]
      (alter-meta!* s update :description-stack pop))))
 
-(defn- format-description
+(defn ^:private format-description
   [strs]
   (str/join " -> " strs))
 
-(defn- description-stack [s]
+(defn ^:private description-stack [s]
   (-> s meta :description-stack))
+
+(defn ^:private string-expr? [x]
+  (or (string? x)
+      (and (sequential? x)
+           (or (= (first x) 'str)
+               (= (first x) 'clojure.core/str)))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Public API
 
 (defn top-level-description
   "Returns the description passed to the top level flow (or the
@@ -63,12 +72,6 @@
   []
   (m/mlet [desc-list (state/gets description-stack)]
     (m/return (format-description desc-list))))
-
-(defn- string-expr? [x]
-  (or (string? x)
-      (and (sequential? x)
-           (or (= (first x) 'str)
-               (= (first x) 'clojure.core/str)))))
 
 (defmacro flow
   "Defines a flow"

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -70,7 +70,7 @@
   [flow initial-state]
   (let [result (run flow initial-state)]
     (when (e/failure? (first result))
-      (let [description (->> result second :meta :description last
+      (let [description (->> result second meta :description last
                              description->string)
             message (str "Flow " "\"" description "\"" " failed with exception")]
         (log/info (m/extract (first result)) message)

--- a/src/state_flow/labs/cljtest.clj
+++ b/src/state_flow/labs/cljtest.clj
@@ -6,6 +6,6 @@
 (defmacro testing [desc & body]
   "state-flow's equivalent to clojure test's `testing`"
   `(core/flow ~desc
-              [full-desc# (core/get-description)]
+              [full-desc# (core/current-description)]
               (state/wrap-fn #(do ~(with-meta `(ctest/testing ~desc ~@body)
                                      (meta &form))))))

--- a/src/state_flow/midje.clj
+++ b/src/state_flow/midje.clj
@@ -27,7 +27,7 @@
   (let [the-meta  (meta &form)
         fact-sexp `(fact ~left-value => ~right-value)]
     `(core/flow ~desc
-       [full-desc# (core/get-description)]
+       [full-desc# (core/current-description)]
        (if (state/state? ~left-value)
          (verify-probe full-desc# ~left-value ~right-value ~the-meta)
          (state/wrap-fn #(do (add-desc-and-meta ~fact-sexp full-desc# ~the-meta)


### PR DESCRIPTION
Also add `top-level-description` function and refactor some internals

- simplify description functionality
  - no need to maintain log
- document some non-API fns that must be public as "for internal use"