### PR TITLE
provide a more friendly error when illegal arg passed to flow

### DIFF
--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -97,8 +97,8 @@
   (let [pair (state/run flow initial-state)]
     (if-let [m (some->> pair first :failure .getMessage (re-find #"cats.protocols\/Extract.*for (.*)$"))]
       (d/pair (#'cats.monad.exception/->Failure
-               (ex-info (format "Expected flow, got %s" (last m))
-                        {})) (second pair))
+               (ex-info (format "Expected flow, got %s" (last m)) {}))
+              (second pair))
       pair)))
 
 (defn run!

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -2,6 +2,7 @@
   (:refer-clojure :exclude [run!])
   (:require [clojure.string :as str]
             [cats.core :as m]
+            [cats.data :as d]
             [cats.monad.exception :as e]
             [state-flow.state :as state]
             [taoensso.timbre :as log]))
@@ -93,7 +94,12 @@
   [flow initial-state]
   (assert (state/state? flow) "First argument must be a flow")
   (assert (map? initial-state) "Initial state must be a map")
-  (state/run flow initial-state))
+  (let [pair (state/run flow initial-state)]
+    (if-let [m (some->> pair first :failure .getMessage (re-find #"cats.protocols\/Extract.*for (.*)$"))]
+      (d/pair (#'cats.monad.exception/->Failure
+               (ex-info (format "Expected flow, got %s" (last m))
+                        {})) (second pair))
+      pair)))
 
 (defn run!
   "Like run, but prints a log and throws an error when the flow fails with an exception"

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -95,9 +95,9 @@
   (assert (state/state? flow) "First argument must be a flow")
   (assert (map? initial-state) "Initial state must be a map")
   (let [pair (state/run flow initial-state)]
-    (if-let [m (some->> pair first :failure .getMessage (re-find #"cats.protocols\/Extract.*for (.*)$"))]
+    (if-let [illegal-arg (some->> pair first :failure .getMessage (re-find #"cats.protocols\/Extract.*for (.*)$") last)]
       (d/pair (#'cats.monad.exception/->Failure
-               (ex-info (format "Expected flow, got %s" (last m)) {}))
+               (ex-info (format "Expected a flow, got %s" illegal-arg) {}))
               (second pair))
       pair)))
 

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -216,3 +216,22 @@
                     (flow "level 3"))
                   (flow "level 2 again"
                     (flow "level 3 again"))))))))
+
+(deftest illegal-flow-args
+  (testing "produce friendly failure messages"
+    (is (re-find #"Expected flow.*got.*identity"
+                 (->> (state-flow/run
+                        (flow "flow" identity)
+                        {})
+                      first
+                      :failure
+                      .getMessage)))
+    (is (re-find #"Expected flow.*got.*identity"
+                 (->> (state-flow/run
+                        (flow "flow"
+                          [x identity]
+                          (state/gets))
+                        {})
+                      first
+                      :failure
+                      .getMessage)))))


### PR DESCRIPTION
This is an alternate implementation of #44 based on feedback from @sovelten and @philomates.

Given:

```clojure
(ns state-flow.scratch
  (:require [state-flow.core :as state-flow]))

(state-flow/run
  (state-flow/flow "flow" identity)
  {})
```

Before:
```
#<Pair [#<Failure #error {
 :cause "No implementation of method: :-extract of protocol: #'cats.protocols/Extract found for class: clojure.core$identity"
 :via
 [{:type java.lang.IllegalArgumentException
   :message "No implementation of method: :-extract of protocol: #'cats.protocols/Extract found for class: clojure.core$identity"
   :at [clojure.core$_cache_protocol_fn invokeStatic "core_deftype.clj" 583]}]
 :trace
 [[clojure.core$_cache_protocol_fn invokeStatic "core_deftype.clj" 583]
  [clojure.core$_cache_protocol_fn invoke "core_deftype.clj" 575]
  [cats.protocols$eval6056$fn__6057$G__6047__6062 invoke "protocols.cljc" 56]
  [state_flow.state$reify__31207$fn__31213 invoke "state.clj" 34]
  [clojure.lang.AFn applyToHelper "AFn.java" 154]
  [clojure.lang.AFn applyTo "AFn.java" 144]
  [clojure.core$apply invokeStatic "core.clj" 665]
  [clojure.core$apply invoke "core.clj" 660]
  [cats.monad.exception$wrap$fn__6790$func__6772__auto____6791 invoke "exception.cljc" 250]
  [cats.monad.exception$exec_try_on invokeStatic "exception.cljc" 197]
  [cats.monad.exception$exec_try_on invoke "exception.cljc" 193]
  [cats.monad.exception$wrap$fn__6790 doInvoke "exception.cljc" 250]
  [clojure.lang.RestFn invoke "RestFn.java" 408]
  [state_flow.state$reify__31207$fn__31213 invoke "state.clj" 39]
  [cats.monad.state$run invokeStatic "state.cljc" 147]
  [cats.monad.state$run invoke "state.cljc" 136]
  [state_flow.core$run invokeStatic "core.clj" 93]
  [state_flow.core$run invoke "core.clj" 89]
  [state_flow.scratch$eval46759 invokeStatic "form-init10940428466068285085.clj" 4]
  [state_flow.scratch$eval46759 invoke "form-init10940428466068285085.clj" 4]
  [clojure.lang.Compiler eval "Compiler.java" 7177]
  [clojure.lang.Compiler eval "Compiler.java" 7132]
  [clojure.core$eval invokeStatic "core.clj" 3214]
  [clojure.core$eval invoke "core.clj" 3210]
  [clojure.main$repl$read_eval_print__9086$fn__9089 invoke "main.clj" 437]
  [clojure.main$repl$read_eval_print__9086 invoke "main.clj" 437]
  [clojure.main$repl$fn__9095 invoke "main.clj" 458]
  [clojure.main$repl invokeStatic "main.clj" 458]
  [clojure.main$repl doInvoke "main.clj" 368]
  [clojure.lang.RestFn invoke "RestFn.java" 1523]
  [nrepl.middleware.interruptible_eval$evaluate invokeStatic "interruptible_eval.clj" 79]
  [nrepl.middleware.interruptible_eval$evaluate invoke "interruptible_eval.clj" 55]
  [nrepl.middleware.interruptible_eval$interruptible_eval$fn__928$fn__932 invoke "interruptible_eval.clj" 142]
  [clojure.lang.AFn run "AFn.java" 22]
  [nrepl.middleware.session$session_exec$main_loop__1029$fn__1033 invoke "session.clj" 171]
  [nrepl.middleware.session$session_exec$main_loop__1029 invoke "session.clj" 170]
  [clojure.lang.AFn run "AFn.java" 22]
  [java.lang.Thread run "Thread.java" 834]]}> {}]>
```


After:
```
#<Pair [#<Failure #error {
 :cause "Expected flow, got class: clojure.core$identity"
 :data {}
 :via
 [{:type clojure.lang.ExceptionInfo
   :message "Expected flow, got class: clojure.core$identity"
   :data {}
   :at [state_flow.core$run invokeStatic "core.clj" 97]}]
 :trace
 [[state_flow.core$run invokeStatic "core.clj" 97]
  [state_flow.core$run invoke "core.clj" 90]
  [state_flow.scratch$eval45735 invokeStatic "form-init10940428466068285085.clj" 4]
  [state_flow.scratch$eval45735 invoke "form-init10940428466068285085.clj" 4]
  [clojure.lang.Compiler eval "Compiler.java" 7177]
  [clojure.lang.Compiler eval "Compiler.java" 7132]
  [clojure.core$eval invokeStatic "core.clj" 3214]
  [clojure.core$eval invoke "core.clj" 3210]
  [clojure.main$repl$read_eval_print__9086$fn__9089 invoke "main.clj" 437]
  [clojure.main$repl$read_eval_print__9086 invoke "main.clj" 437]
  [clojure.main$repl$fn__9095 invoke "main.clj" 458]
  [clojure.main$repl invokeStatic "main.clj" 458]
  [clojure.main$repl doInvoke "main.clj" 368]
  [clojure.lang.RestFn invoke "RestFn.java" 1523]
  [nrepl.middleware.interruptible_eval$evaluate invokeStatic "interruptible_eval.clj" 79]
  [nrepl.middleware.interruptible_eval$evaluate invoke "interruptible_eval.clj" 55]
  [nrepl.middleware.interruptible_eval$interruptible_eval$fn__928$fn__932 invoke "interruptible_eval.clj" 142]
  [clojure.lang.AFn run "AFn.java" 22]
  [nrepl.middleware.session$session_exec$main_loop__1029$fn__1033 invoke "session.clj" 171]
  [nrepl.middleware.session$session_exec$main_loop__1029 invoke "session.clj" 170]
  [clojure.lang.AFn run "AFn.java" 22]
  [java.lang.Thread run "Thread.java" 834]]}> {}]>
```