### PR TITLE
fix failing test

### DIFF
--- a/test/state_flow/probe_test.clj
+++ b/test/state_flow/probe_test.clj
@@ -11,8 +11,8 @@
            (first (state-flow/run (probe/probe test-helpers/add-two #(= % 3)) {:value 1})))))
   (testing "add two with small delay"
     (let [state {:value (atom 0)}]
-      (is (= (d/pair nil state))
-          (state-flow/run (test-helpers/delayed-add-two 100) state))
+      (is (= (d/pair nil state)
+             (state-flow/run (test-helpers/delayed-add-two 100) state)))
       (is (= (d/pair [true 2] state)
              (state-flow/run (probe/probe test-helpers/get-value-state #(= 2 %)) state)))))
   (testing "add two with too much delay"


### PR DESCRIPTION
For reasons unknown, this test was passing when running `lein test` but threw an exception when running in an REPL (`=` requires 2 args).