### PR TITLE
refactor tests

### DIFF
--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -1,7 +1,6 @@
 (ns state-flow.core-test
   (:require [clojure.test :as t :refer [deftest testing is]]
             [matcher-combinators.test :refer [match?]]
-            [cats.core :as cats]
             [state-flow.test-helpers :as test-helpers]
             [state-flow.core :as state-flow :refer [flow]]
             [state-flow.state :as state]))

--- a/test/state_flow/labs/cljtest_test.clj
+++ b/test/state_flow/labs/cljtest_test.clj
@@ -1,7 +1,7 @@
 (ns state-flow.labs.cljtest-test
   (:require [clojure.test :as t :refer [deftest testing is]]
             [matcher-combinators.test :refer [match?]]
-            [state-flow.test-helpers :as th]
+            [state-flow.test-helpers :as test-helpers]
             [state-flow.labs.cljtest :as labs.cljtest]
             [state-flow.core :as state-flow]
             [state-flow.state :as state]))
@@ -9,11 +9,11 @@
 (deftest testing-macro
   (testing "works for failure cases"
     (let [{:keys [flow-ret flow-state]}
-          (th/run-flow (state-flow/flow "desc"
-                         [v (state/gets :value)]
-                         (labs.cljtest/testing "contains with monadic left value"
-                           (is (= {:a 1 :b 5} v))))
-                       {:value {:a 2 :b 5}})]
+          (test-helpers/run-flow (state-flow/flow "desc"
+                                   [v (state/gets :value)]
+                                   (labs.cljtest/testing "contains with monadic left value"
+                                     (is (= {:a 1 :b 5} v))))
+                                 {:value {:a 2 :b 5}})]
       (is (false? flow-ret))
       (is (match? {:value {:a 2 :b 5}}
                   flow-state)))))

--- a/test/state_flow/probe_test.clj
+++ b/test/state_flow/probe_test.clj
@@ -1,23 +1,30 @@
 (ns state-flow.probe-test
   (:require [clojure.test :as t :refer [deftest testing is]]
-            [cats.data :as d]
             [state-flow.core :as state-flow]
             [state-flow.probe :as probe]
             [state-flow.test-helpers :as test-helpers]))
 
 (deftest test-probe
-  (testing "add two to state 1, result is 3, doesn't change world"
-    (is (= [true 3]
-           (first (state-flow/run (probe/probe test-helpers/add-two #(= % 3)) {:value 1})))))
-  (testing "add two with small delay"
+  (let [[flow-return flow-state] (state-flow/run (probe/probe test-helpers/add-two #(= % 3)) {:value 1})]
+    (testing "returns a tuple of [check-fn-result state-fn-return]"
+      (is (= [true 3] flow-return)))
+    (testing "doesn't change state if state-fn doesn't change state"
+      (is (= {:value 1} flow-state))))
+  (testing "with delay < timeout"
     (let [state {:value (atom 0)}]
-      (is (= (d/pair nil state)
-             (state-flow/run (test-helpers/delayed-add-two 100) state)))
-      (is (= (d/pair [true 2] state)
-             (state-flow/run (probe/probe test-helpers/get-value-state #(= 2 %)) state)))))
-  (testing "add two with too much delay"
-        (let [state {:value (atom 0)}]
-          (is (= (d/pair nil state)
-                 (state-flow/run (test-helpers/delayed-add-two 4000) state)))
-          (is (= (d/pair [false 0] state)
-                 (state-flow/run (probe/probe test-helpers/get-value-state #(= 2 %)) state))))))
+      (is (= 0 (->> (state-flow/run (test-helpers/delayed-add-two 100) state) last :value deref)))
+      (is (= [true 2]
+             (first (state-flow/run (probe/probe test-helpers/get-value-state #(= 2 %)) state))))))
+  (testing "with delay > timeout"
+    (let [state {:value (atom 0)}]
+      (is (= 0 (->> (state-flow/run (test-helpers/delayed-add-two 1500) state) last :value deref)))
+      (is (= [false 0]
+             (first (state-flow/run (probe/probe test-helpers/get-value-state #(= 2 %)) state))))))
+  (testing "with modified sleep-time and times-to-try"
+    (let [state {:value (atom 0)}]
+      (is (= 0 (->> (state-flow/run (test-helpers/delayed-add-two 1100) state) last :value deref)))
+      (is (= [true 2]
+             (first (state-flow/run (probe/probe test-helpers/get-value-state #(= 2 %)
+                                                 {:sleep-time   250
+                                                  :times-to-try 5})
+                      state)))))))

--- a/test/state_flow/state_test.clj
+++ b/test/state_flow/state_test.clj
@@ -3,14 +3,13 @@
             [cats.core :as m]
             [cats.data :as d]
             [cats.monad.exception :as e]
-            [cats.monad.state :as state]
-            [state-flow.state :as sf.state]))
+            [state-flow.state :as state]))
 
 (deftest state
-  (let [increment-state       (m/mlet [x (sf.state/get)
-                                       _ (sf.state/put (inc x))]
-                                      (m/return x))
-        double-state          (sf.state/modify #(* 2 %))]
+  (let [increment-state (m/mlet [x (state/get)
+                                 _ (state/put (inc x))]
+                                (m/return x))
+        double-state    (state/modify #(* 2 %))]
     (testing "modify state with get and put"
       (is (= (d/pair 2 3)
              (state/run increment-state 2))))
@@ -20,7 +19,7 @@
     (testing "state with an exception"
       (let [[res state] (state/run (m/>> double-state
                                          double-state
-                                         (sf.state/modify (fn [s] (throw (Exception. "My exception"))))
+                                         (state/modify (fn [s] (throw (Exception. "My exception"))))
                                          double-state) 2)]
         (is (e/failure? res))
         (is (= 8 state))))))

--- a/test/state_flow/test_helpers.clj
+++ b/test/state_flow/test_helpers.clj
@@ -1,24 +1,22 @@
 (ns state-flow.test-helpers
-  (:require [cats.core :as m]
-            [cats.data :as d]
-            [cats.monad.state :as state]
-            [state-flow.core]
-            [state-flow.state :as sf.state]))
+  (:require [state-flow.core]
+            [state-flow.state :as state]))
 
 (def get-value (comp deref :value))
 (def get-value-state (state/gets get-value))
 
 (def add-two
-  (m/mlet [state (sf.state/get)]
-    (m/return (+ 2 (-> state :value)))))
+  (state/gets (comp (partial + 2) :value)))
 
 (defn delayed-add-two
   [delay-ms]
   "Changes state in the future"
-  (state/state (fn [state]
-                 (future (do (Thread/sleep delay-ms)
-                             (swap! (:value state) + 2)))
-                 (d/pair nil state))))
+  (state/modify (fn [state]
+                      (future (do (Thread/sleep delay-ms)
+                                  (swap! (:value state) + 2)))
+                      state)))
+
+
 
 (defmacro run-flow
   "Same as state-flow.core/run! except does not report exceptions to *out* or test results from


### PR DESCRIPTION
* express tests in terms of state-flow instead of cats where possible
    * only the state test uses lower level cats functions
* add tests to demo config args to probe fn
* align aliases across test namespaces
 