### PR TITLE
make `return` constructable/def'able

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## [DEV]
+## [2.1.5]
+
+- Make `state-flow.state/return` constructable/def'able outside monadic context.
 
 ## [2.1.4]
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "2.1.4"
+(defproject nubank/state-flow "2.1.5"
   :description "Postman-like integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}

--- a/src/state_flow/state.clj
+++ b/src/state_flow/state.clj
@@ -81,7 +81,7 @@
 (defn return
   "Returns the equivalent of (fn [state] [v, state])"
   [v]
-  (m/return v))
+  (m/return error-context v))
 
 (defn ^:deprecated swap
   "DEPRECATED: use modify"

--- a/test/state_flow/state_test.clj
+++ b/test/state_flow/state_test.clj
@@ -6,6 +6,12 @@
             [state-flow.state :as state]))
 
 (deftest state
+  (testing "primitives are constructable outside monad context"
+    (state/get)
+    (state/gets inc)
+    (state/modify inc)
+    (state/return 37)
+    (state/put {:count 0}))
   (let [increment-state (m/mlet [x (state/get)
                                  _ (state/put (inc x))]
                                 (m/return x))


### PR DESCRIPTION
I was writing up some intro docs and tried to evaluate `(state/return 37)` and got an exception. I think `return`, like the other primitives, should be constructable and def'able.