### PR TITLE
capture match results and add them to metadata of state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [5.10.0]
 
-* add filename to flow descriptions. Use the following format: `<description> (<file>:<line>)`
+* Pushed test report to state metadata everytime an assertion is done with match?
+* Removed clojure.test assertion from match?
+* Clojure.test assertions are made on defflow macro, after flow is run, by calling clojure.test/report directly
 
 ## [5.9.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [5.10.0]
+
+* add filename to flow descriptions. Use the following format: `<description> (<file>:<line>)`
+
 ## [5.9.0]
 
 * add filename to flow descriptions. Use the following format: `<description> (<file>:<line>)`

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "5.9.0"
+(defproject nubank/state-flow "5.10.0"
   :description "Integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}

--- a/src/state_flow/assertions/matcher_combinators.clj
+++ b/src/state_flow/assertions/matcher_combinators.clj
@@ -2,7 +2,6 @@
   (:require [cats.core :as m]
             [cats.monad.exception :as e]
             [matcher-combinators.standalone :as matcher-combinators]
-            [matcher-combinators.test] ;; to register clojure.test assert-expr for `match?`
             [state-flow.assertions.report :as report]
             [state-flow.core :as core]
             [state-flow.probe :as probe]

--- a/src/state_flow/assertions/matcher_combinators.clj
+++ b/src/state_flow/assertions/matcher_combinators.clj
@@ -3,8 +3,8 @@
             [cats.monad.exception :as e]
             [matcher-combinators.standalone :as matcher-combinators]
             [matcher-combinators.test] ;; to register clojure.test assert-expr for `match?`
-            [state-flow.core :as core]
             [state-flow.assertions.report :as report]
+            [state-flow.core :as core]
             [state-flow.probe :as probe]
             [state-flow.state :as state]))
 

--- a/src/state_flow/assertions/matcher_combinators.clj
+++ b/src/state_flow/assertions/matcher_combinators.clj
@@ -75,7 +75,6 @@
                                          :actual       ~actual}))))
        [flow-desc#  (core/current-description)
         fail-fast?# core/fail-fast?
-        assert-with-clojure-test?# core/assert-with-clojure-test?
         probe-res#  (#'match-probe (state/ensure-step ~actual) ~expected ~params*)
         :let [actual# (-> probe-res# last :value)
               report# (assoc (matcher-combinators/match ~expected actual#)
@@ -84,12 +83,6 @@
                              :probe/results      probe-res#
                              :probe/sleep-time   ~(:sleep-time params*)
                              :probe/times-to-try ~(:times-to-try params*))]]
-
-       (if assert-with-clojure-test?#
-         ;; We only make the clojure.test assertion if the option is enabled
-         ;; The assertion needs to be done here for proper line number information
-         (state/invoke #(~'clojure.test/testing flow-desc# (~'clojure.test/is (~'match? ~expected actual#))))
-         (state/return nil))
 
        (report/push report#)
        (state/return (if (and fail-fast?# (= :mismatch (:match/result report#)))

--- a/src/state_flow/assertions/report.clj
+++ b/src/state_flow/assertions/report.clj
@@ -1,8 +1,8 @@
 (ns state-flow.assertions.report
   (:require
-    [state-flow.core :as core]
-    [state-flow.state :as state]
-    [cats.core :as m]))
+   [cats.core :as m]
+   [state-flow.core :as core]
+   [state-flow.state :as state]))
 
 (defn push
   [assertion-report]

--- a/src/state_flow/assertions/report.clj
+++ b/src/state_flow/assertions/report.clj
@@ -1,7 +1,12 @@
 (ns state-flow.assertions.report
   (:require
-    [state-flow.core :as core]))
+    [state-flow.core :as core]
+    [state-flow.state :as state]
+    [cats.core :as m]))
 
 (defn push
   [assertion-report]
-  (core/modify-meta update :test-report (fnil conj []) assertion-report))
+  (m/do-let
+   [description-stack (state/gets core/description-stack)
+    :let [report (assoc assertion-report :flow/description-stack description-stack)]]
+   (core/modify-meta update-in [:test-report :assertions] (fnil conj []) report)))

--- a/src/state_flow/cljtest.clj
+++ b/src/state_flow/cljtest.clj
@@ -17,6 +17,7 @@
     `(~'state-flow.assertions.matcher-combinators/match? ~expected ~actual ~params*)))
 
 (defn clojure-test-report
+  "Internal use only, subject to change"
   [{:match/keys [result expected actual]
     :flow/keys [description-stack]
     :as assertion-report}]
@@ -25,8 +26,8 @@
      :message message
      :expected expected
      :actual actual
-     :file (-> assertion-report :flow/description-stack last :file)
-     :line (-> assertion-report :flow/description-stack last :line)}))
+     :file (-> description-stack last core/description->file)
+     :line (-> description-stack last :line)}))
 
 (defmacro defflow
   {:doc "Creates a flow and binds it a Var named by name"

--- a/src/state_flow/cljtest.clj
+++ b/src/state_flow/cljtest.clj
@@ -1,7 +1,6 @@
 (ns state-flow.cljtest
   (:require [clojure.test :as t]
             [state-flow.assertions.matcher-combinators]
-            [matcher-combinators.test] ;; to register clojure.test assert-expr for `match?`
             [state-flow.core :as core]
             [state-flow.probe :as probe]))
 

--- a/src/state_flow/cljtest.clj
+++ b/src/state_flow/cljtest.clj
@@ -39,7 +39,7 @@
                                (cons {} forms))]
     `(t/deftest ~name
        (let [[ret# state#] (core/run* ~parameters (core/flow ~(str name) ~@flows))
-             test-report# (get (meta state#) :test-report)]
-         (doseq [assertion-data# (:assertions test-report#)]
+             assertions# (get-in (meta state#) [:test-report :assertions])]
+         (doseq [assertion-data# assertions#]
            (t/report (clojure-test-report assertion-data#)))
          [ret# state#]))))

--- a/src/state_flow/cljtest.clj
+++ b/src/state_flow/cljtest.clj
@@ -1,10 +1,10 @@
 (ns state-flow.cljtest
   (:require [clojure.test :as t]
-            [matcher-combinators.test] ;; to register clojure.test assert-expr for `match?`
+            [matcher-combinators.printer :as matcher-combinators.printer] ;; to register clojure.test assert-expr for `match?`
+            [matcher-combinators.test]
             [state-flow.assertions.matcher-combinators]
             [state-flow.core :as core]
-            [state-flow.probe :as probe]
-            [matcher-combinators.printer :as matcher-combinators.printer]))
+            [state-flow.probe :as probe]))
 
 (defmacro ^:deprecated match?
   "DEPRECATED. Use state-flow.assertions.matcher-combinators/match? instead. "

--- a/src/state_flow/cljtest.clj
+++ b/src/state_flow/cljtest.clj
@@ -16,13 +16,6 @@
                        params)]
     `(~'state-flow.assertions.matcher-combinators/match? ~expected ~actual ~params*)))
 
-(defn report->assertion
-  [assertion-report]
-  (let [description (core/format-description (:flow/description-stack assertion-report))
-        expected (:match/expected assertion-report)
-        actual (:match/actual assertion-report)]
-    (t/testing description (t/is (match? expected actual)))))
-
 (defmacro defflow
   {:doc "Creates a flow and binds it a Var named by name"
    :arglists '([name & flows]
@@ -30,10 +23,7 @@
   [name & forms]
   (let [[parameters & flows] (if (map? (first forms))
                                forms
-                               (cons {} forms))]
+                               (cons {} forms))
+        parameters' (assoc parameters :assert-with-clojure-test? true)]
     `(t/deftest ~name
-       (let [[ret# final-state#] (core/run* ~parameters (core/flow ~(str name) ~@flows))
-             test-report# (get (meta final-state#) :test-report)]
-         (doseq [assertion# (:assertions test-report#)]
-           (report->assertion assertion#))
-         [ret# final-state#]))))
+       (core/run* ~parameters' (core/flow ~(str name) ~@flows)))))

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -56,8 +56,8 @@
            (format " (%s:%s)" filename line)))))
 
 (defn format-description
-  [strs]
-  (->> strs
+  [stack]
+  (->> stack
        (map format-single-description)
        (str/join " -> ")))
 
@@ -265,7 +265,7 @@
                         `(comp throw-error!
                               log-error
                               (filter-stack-trace default-strack-trace-exclusions))`"
-  [{:keys [init cleanup runner on-error fail-fast? before-flow-hook assert-with-clojure-test?]
+  [{:keys [init cleanup runner on-error fail-fast? before-flow-hook]
     :or   {init                   (constantly {})
            cleanup                identity
            runner                 run
@@ -280,8 +280,7 @@
                                    assoc
                                    :runner runner
                                    :before-flow-hook before-flow-hook
-                                   :fail-fast? fail-fast?
-                                   :assert-with-clojure-test? assert-with-clojure-test?)
+                                   :fail-fast? fail-fast?)
         pair            (-> flow
                             (runner init-state+meta)
                             clarify-illegal-arg

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -87,6 +87,12 @@
   For internal use. Subject to change."
   (state/gets (comp :fail-fast? meta)))
 
+(def assert-with-clojure-test?
+  "Should the flow stop after the first failing assertion?
+
+  For internal use. Subject to change."
+  (state/gets (comp :assert-with-clojure-test? meta)))
+
 (defn- clarify-illegal-arg [pair]
   (if-let [illegal-arg (some->> pair first :failure .getMessage (re-find #"cats.protocols\/Extract.*for (.*)$") last)]
     [(#'cats.monad.exception/->Failure
@@ -259,7 +265,7 @@
                         `(comp throw-error!
                               log-error
                               (filter-stack-trace default-strack-trace-exclusions))`"
-  [{:keys [init cleanup runner on-error fail-fast? before-flow-hook]
+  [{:keys [init cleanup runner on-error fail-fast? before-flow-hook assert-with-clojure-test?]
     :or   {init                   (constantly {})
            cleanup                identity
            runner                 run
@@ -267,14 +273,15 @@
            before-flow-hook       identity
            on-error               (comp throw-error!
                                         log-error
-                                        (filter-stack-trace default-stack-trace-exclusions))}
-    :as   opts}
+                                        (filter-stack-trace default-stack-trace-exclusions))
+           assert-with-clojure-test? false}}
    flow]
   (let [init-state+meta (vary-meta (init)
                                    assoc
                                    :runner runner
                                    :before-flow-hook before-flow-hook
-                                   :fail-fast? fail-fast?)
+                                   :fail-fast? fail-fast?
+                                   :assert-with-clojure-test? assert-with-clojure-test?)
         pair            (-> flow
                             (runner init-state+meta)
                             clarify-illegal-arg

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -72,7 +72,6 @@
 (defn description-stack [s]
   (-> s meta :description-stack))
 
-
 (defn ^:private string-expr? [x]
   (or (string? x)
       (and (sequential? x)

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -48,9 +48,17 @@
   []
   (modify-meta update :description-stack pop))
 
+;;
+;; Begin description utils
+;;
+
+(defn description->file
+  [{:keys [file]}]
+  (when file (last (str/split file #"/"))))
+
 (defn ^:private format-single-description
   [{:keys [line description file] :as m}]
-  (let [filename (when file (last (str/split file #"/")))]
+  (let [filename (description->file m)]
     (str description
          (when line
            (format " (%s:%s)" filename line)))))
@@ -63,6 +71,7 @@
 
 (defn description-stack [s]
   (-> s meta :description-stack))
+
 
 (defn ^:private string-expr? [x]
   (or (string? x)
@@ -80,6 +89,10 @@
   For internal use. Subject to change."
   []
   (state/gets state->current-description))
+
+;;
+;; End description utils
+;;
 
 (def fail-fast?
   "Should the flow stop after the first failing assertion?

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -273,8 +273,7 @@
            before-flow-hook       identity
            on-error               (comp throw-error!
                                         log-error
-                                        (filter-stack-trace default-stack-trace-exclusions))
-           assert-with-clojure-test? false}}
+                                        (filter-stack-trace default-stack-trace-exclusions))}}
    flow]
   (let [init-state+meta (vary-meta (init)
                                    assoc

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -69,7 +69,9 @@
        (map format-single-description)
        (str/join " -> ")))
 
-(defn description-stack [s]
+(defn description-stack
+  "For internal use. Subject to change"
+  [s]
   (-> s meta :description-stack))
 
 (defn ^:private string-expr? [x]

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -55,13 +55,13 @@
          (when line
            (format " (%s:%s)" filename line)))))
 
-(defn ^:private format-description
+(defn format-description
   [strs]
   (->> strs
        (map format-single-description)
        (str/join " -> ")))
 
-(defn ^:private description-stack [s]
+(defn description-stack [s]
   (-> s meta :description-stack))
 
 (defn ^:private string-expr? [x]

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -88,7 +88,7 @@
   (state/gets (comp :fail-fast? meta)))
 
 (def assert-with-clojure-test?
-  "Should the flow stop after the first failing assertion?
+  "Flow that returns value of assert-with-clojure-test? config option
 
   For internal use. Subject to change."
   (state/gets (comp :assert-with-clojure-test? meta)))

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -101,12 +101,6 @@
   For internal use. Subject to change."
   (state/gets (comp :fail-fast? meta)))
 
-(def assert-with-clojure-test?
-  "Flow that returns value of assert-with-clojure-test? config option
-
-  For internal use. Subject to change."
-  (state/gets (comp :assert-with-clojure-test? meta)))
-
 (defn- clarify-illegal-arg [pair]
   (if-let [illegal-arg (some->> pair first :failure .getMessage (re-find #"cats.protocols\/Extract.*for (.*)$") last)]
     [(#'cats.monad.exception/->Failure

--- a/test/state_flow/assertions/matcher_combinators_test.clj
+++ b/test/state_flow/assertions/matcher_combinators_test.clj
@@ -61,10 +61,10 @@
     (let [three-lines-before-call-to-match (this-line-number)
           [flow-ret flow-state]
           (state-flow/run
-            (mc/match? (matchers/equals {:n 1})
-                       (state/gets :value)
-                       {:times-to-try 2})
-            {:value {:n 2}})]
+           (mc/match? (matchers/equals {:n 1})
+                      (state/gets :value)
+                      {:times-to-try 2})
+           {:value {:n 2}})]
       (testing "returns match result"
         (is (match? {:match/result       :mismatch
                      :mismatch/detail    {:n {:expected 1 :actual 2}}
@@ -90,13 +90,13 @@
   (testing "with probe result that only changes after timeout"
     (let [[flow-ret flow-state]
           (state-flow/run
-            (flow "flow"
-              (test-helpers/swap-later 200 :count + 2)
-              (testing "2" (mc/match? 2
-                                      (state/gets (comp deref :count))
-                                      {:times-to-try 2
-                                       :sleep-time   75})))
-            {:count (atom 0)})]
+           (flow "flow"
+             (test-helpers/swap-later 200 :count + 2)
+             (testing "2" (mc/match? 2
+                                     (state/gets (comp deref :count))
+                                     {:times-to-try 2
+                                      :sleep-time   75})))
+           {:count (atom 0)})]
       (testing "returns match result"
         (is (match? {:match/result :mismatch} flow-ret)))
       (testing "pushes test report to metadata"

--- a/test/state_flow/assertions/matcher_combinators_test.clj
+++ b/test/state_flow/assertions/matcher_combinators_test.clj
@@ -80,7 +80,18 @@
           (= (+ three-lines-before-call-to-match 3) (:line report-data)))
         (is (match? {:matcher-combinators.result/type  :mismatch
                      :matcher-combinators.result/value {:n {:expected 1 :actual 2}}}
-                    (-> report-data :actual :match-result))))))
+                    (-> report-data :actual :match-result))))
+      (testing "saves assertion report to state with current description stack"
+        (is (match? {:flow/description-stack [{:description "match?"}]
+                     :match/result       :mismatch
+                     :mismatch/detail    {:n {:expected 1 :actual 2}}
+                     :probe/results      [{:check-result false :value {:n 2}}
+                                          {:check-result false :value {:n 2}}]
+                     :probe/sleep-time   200
+                     :probe/times-to-try 2
+                     :match/expected     {:expected {:n 1}}
+                     :match/actual       {:n 2}}
+                    (first (get-in (meta flow-state) [:test-report :assertions])))))))
 
   (testing "with probe result that only changes after timeout"
     (let [{:keys [flow-ret flow-state report-data]}

--- a/test/state_flow/assertions/matcher_combinators_test.clj
+++ b/test/state_flow/assertions/matcher_combinators_test.clj
@@ -75,12 +75,6 @@
                      :match/expected     {:expected {:n 1}}
                      :match/actual       {:n 2}}
                     flow-ret)))
-      (testing "reports match-results to clojure.test"
-        (testing "including the line number where match? was called"
-          (= (+ three-lines-before-call-to-match 3) (:line report-data)))
-        (is (match? {:matcher-combinators.result/type  :mismatch
-                     :matcher-combinators.result/value {:n {:expected 1 :actual 2}}}
-                    (-> report-data :actual :match-result))))
       (testing "saves assertion report to state with current description stack"
         (is (match? {:flow/description-stack [{:description "match?"}]
                      :match/result       :mismatch
@@ -105,10 +99,11 @@
            {:count (atom 0)})]
       (testing "returns match result"
         (is (match? {:match/result :mismatch} flow-ret)))
-      (testing "reports match-results to clojure.test"
-        (is (match? {:matcher-combinators.result/type  :mismatch
-                     :matcher-combinators.result/value {:expected 2 :actual 0}}
-                    (-> report-data :actual :match-result))))))
+      (testing "pushes test report to metadata"
+        (is (match? {:match/result  :mismatch
+                     :match/expected 2
+                     :match/actual 0}
+                    (-> (meta flow-state) :test-report :assertions first))))))
 
   (testing "with times-to-try > 1 and a value instead of a step"
     (testing "throws"

--- a/test/state_flow/assertions/matcher_combinators_test.clj
+++ b/test/state_flow/assertions/matcher_combinators_test.clj
@@ -103,7 +103,7 @@
         (is (match? {:match/result  :mismatch
                      :match/expected 2
                      :match/actual 0}
-                    (-> (meta flow-state) :test-report :assertions first))))))
+                    (first (get-in (meta flow-state) [:test-report :assertions])))))))
 
   (testing "with times-to-try > 1 and a value instead of a step"
     (testing "throws"

--- a/test/state_flow/cljtest_test.clj
+++ b/test/state_flow/cljtest_test.clj
@@ -30,7 +30,7 @@
                   (#'cljtest/clojure-test-report report))))
     (testing "we save pretty printing metadata"
       (is (match? {:type :state-flow.cljtest/mismatch}
-           (meta (:actual (#'cljtest/clojure-test-report match-report))))))))
+                  (meta (:actual (#'cljtest/clojure-test-report match-report))))))))
 
 (deftest run-a-flow
   ;; NOTE:(sovelten,2020-12-15) This test works when called via clojure.test/run-tests

--- a/test/state_flow/cljtest_test.clj
+++ b/test/state_flow/cljtest_test.clj
@@ -19,12 +19,12 @@
                  :actual 2
                  :file "my-test-file.clj"
                  :line 23}
-         (cljtest/clojure-test-report {:match/expected 1
-                                       :match/actual 2
-                                       :match/result :mismatch
-                                       :flow/description-stack [{:description "my test"
-                                                                 :file "my-test-file.clj"
-                                                                 :line 23}]})))))
+                (cljtest/clojure-test-report {:match/expected 1
+                                              :match/actual 2
+                                              :match/result :mismatch
+                                              :flow/description-stack [{:description "my test"
+                                                                        :file "my-test-file.clj"
+                                                                        :line 23}]})))))
 
 (deftest run-a-flow
   ;; NOTE:(sovelten,2020-12-15) This test works when called via clojure.test/run-tests

--- a/test/state_flow/cljtest_test.clj
+++ b/test/state_flow/cljtest_test.clj
@@ -35,8 +35,8 @@
     (is (= '(clojure.test/deftest
               my-flow
               (state-flow.core/run*
-                {:init (constantly {:value 1})
-                 :assert-with-clojure-test? true}
+               {:init (constantly {:value 1})
+                :assert-with-clojure-test? true}
                (state-flow.core/flow "my-flow" (testing "equals" (mc/match? 1 1)))))
            flow-with-optional-args)))
 
@@ -44,8 +44,8 @@
     (is (= '(clojure.test/deftest
               my-flow
               (state-flow.core/run*
-                {:init (constantly {:map {:a 1 :b 2} :value 1})
-                 :assert-with-clojure-test? true}
+               {:init (constantly {:map {:a 1 :b 2} :value 1})
+                :assert-with-clojure-test? true}
                (state-flow.core/flow
                 "my-flow"
                  [value (state/gets :value)]

--- a/test/state_flow/cljtest_test.clj
+++ b/test/state_flow/cljtest_test.clj
@@ -27,7 +27,7 @@
     (is (= '(clojure.test/deftest
               my-flow
               (state-flow.core/run*
-               {}
+               {:assert-with-clojure-test? true}
                (state-flow.core/flow "my-flow" (testing "equals" (mc/match? 1 1)))))
            flow-with-defaults)))
 
@@ -35,7 +35,8 @@
     (is (= '(clojure.test/deftest
               my-flow
               (state-flow.core/run*
-               {:init (constantly {:value 1})}
+                {:init (constantly {:value 1})
+                 :assert-with-clojure-test? true}
                (state-flow.core/flow "my-flow" (testing "equals" (mc/match? 1 1)))))
            flow-with-optional-args)))
 
@@ -43,7 +44,8 @@
     (is (= '(clojure.test/deftest
               my-flow
               (state-flow.core/run*
-               {:init (constantly {:map {:a 1 :b 2} :value 1})}
+                {:init (constantly {:map {:a 1 :b 2} :value 1})
+                 :assert-with-clojure-test? true}
                (state-flow.core/flow
                 "my-flow"
                  [value (state/gets :value)]

--- a/test/state_flow/cljtest_test.clj
+++ b/test/state_flow/cljtest_test.clj
@@ -3,6 +3,7 @@
             [matcher-combinators.test :refer [match?]]
             [state-flow.assertions.matcher-combinators :as mc]
             [state-flow.cljtest :refer [defflow] :as cljtest]
+            [state-flow.core :as state-flow]
             [state-flow.state :as state]))
 
 (defflow my-flow {:init (constantly {:value 1
@@ -12,19 +13,24 @@
   (testing "b is 2" (mc/match? {:b 2} (state/gets :map))))
 
 (deftest test-clojure-test-report
-  (testing "we adapt state-flow assertion report into clojure-test report format"
-    (is (match? {:type :fail
-                 :message "my test (my-test-file.clj:23)"
-                 :expected 1
-                 :actual 2
-                 :file "my-test-file.clj"
-                 :line 23}
-                (cljtest/clojure-test-report {:match/expected 1
-                                              :match/actual 2
-                                              :match/result :mismatch
-                                              :flow/description-stack [{:description "my test"
-                                                                        :file "my-test-file.clj"
-                                                                        :line 23}]})))))
+  (let [report {:match/expected 1
+                :match/actual 2
+                :match/result :mismatch
+                :flow/description-stack [{:description "my test"
+                                          :file "my-test-file.clj"
+                                          :line 23}]}
+        match-report (first (state-flow/run (mc/match? 1 2) {}))]
+    (testing "we adapt state-flow assertion report into clojure-test report format"
+      (is (match? {:type :fail
+                   :message "my test (my-test-file.clj:23)"
+                   :expected 1
+                   :actual 2
+                   :file "my-test-file.clj"
+                   :line 23}
+                  (#'cljtest/clojure-test-report report))))
+    (testing "we save pretty printing metadata"
+      (is (match? {:type :state-flow.cljtest/mismatch}
+           (meta (:actual (#'cljtest/clojure-test-report match-report))))))))
 
 (deftest run-a-flow
   ;; NOTE:(sovelten,2020-12-15) This test works when called via clojure.test/run-tests

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -153,7 +153,7 @@
 
   (testing "run! throws exception"
     (is (thrown-with-msg? Exception #"root \(core_test.clj:\d+\) -> child2 \(core_test.clj:\d+\)"
-                          (test-helpers/run-flow bogus-flow {:value 0})))))
+                          (state-flow/run bogus-flow {:value 0})))))
 
 (deftest as-step-fn
   (let [add-two-fn (state-flow/as-step-fn (state/modify #(+ 2 %)))]

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -153,7 +153,7 @@
 
   (testing "run! throws exception"
     (is (thrown-with-msg? Exception #"root \(core_test.clj:\d+\) -> child2 \(core_test.clj:\d+\)"
-                          (state-flow/run bogus-flow {:value 0})))))
+                          (test-helpers/shhh! (state-flow/run! bogus-flow {:value 0}))))))
 
 (deftest as-step-fn
   (let [add-two-fn (state-flow/as-step-fn (state/modify #(+ 2 %)))]

--- a/test/state_flow/labs/cljtest_test.clj
+++ b/test/state_flow/labs/cljtest_test.clj
@@ -8,12 +8,12 @@
 
 (deftest testing-macro
   (testing "works for failure cases"
-    (let [{:keys [flow-ret flow-state]}
-          (test-helpers/run-flow (state-flow/flow "desc"
-                                   [v (state/gets :value)]
-                                   (labs.cljtest/testing "contains with monadic left value"
-                                     (is (= {:a 1 :b 5} v))))
-                                 {:value {:a 2 :b 5}})]
+    (let [[flow-ret flow-state]
+          (test-helpers/shhh! (state-flow/run (state-flow/flow "desc"
+                                                [v (state/gets :value)]
+                                                (labs.cljtest/testing "contains with monadic left value"
+                                                  (is (= {:a 1 :b 5} v))))
+                                {:value {:a 2 :b 5}}))]
       (is (false? flow-ret))
       (is (match? {:value {:a 2 :b 5}}
                   flow-state)))))

--- a/test/state_flow/labs/cljtest_test.clj
+++ b/test/state_flow/labs/cljtest_test.clj
@@ -13,7 +13,7 @@
                                                 [v (state/gets :value)]
                                                 (labs.cljtest/testing "contains with monadic left value"
                                                   (is (= {:a 1 :b 5} v))))
-                                {:value {:a 2 :b 5}}))]
+                                              {:value {:a 2 :b 5}}))]
       (is (false? flow-ret))
       (is (match? {:value {:a 2 :b 5}}
                   flow-state)))))

--- a/test/state_flow/test_helpers.clj
+++ b/test/state_flow/test_helpers.clj
@@ -45,9 +45,9 @@
          res#         (with-redefs [clojure.test/do-report (fn [data#] (reset! report-data# data#))]
                         (binding [*out* (clojure.java.io/writer (java.io.File/createTempFile "test" "log"))]
                           (state-flow.core/run*
-                            {:assert-with-clojure-test? true
-                             :init (constantly ~(or state {}))}
-                            ~flow)))]
+                           {:assert-with-clojure-test? true
+                            :init (constantly ~(or state {}))}
+                           ~flow)))]
      {:report-data (->> (deref report-data#)
                         ;; NOTE: :matcher-combinators.result/value is a Mismatch object, which is
                         ;; a defrecord, so equality on a map won't pass, hence pouring it into a map

--- a/test/state_flow/test_helpers.clj
+++ b/test/state_flow/test_helpers.clj
@@ -44,9 +44,10 @@
   `(let [report-data# (atom nil)
          res#         (with-redefs [clojure.test/do-report (fn [data#] (reset! report-data# data#))]
                         (binding [*out* (clojure.java.io/writer (java.io.File/createTempFile "test" "log"))]
-                          (state-flow.core/run!
-                           ~flow
-                           ~(or state {}))))]
+                          (state-flow.core/run*
+                            {:assert-with-clojure-test? true
+                             :init (constantly ~(or state {}))}
+                            ~flow)))]
      {:report-data (->> (deref report-data#)
                         ;; NOTE: :matcher-combinators.result/value is a Mismatch object, which is
                         ;; a defrecord, so equality on a map won't pass, hence pouring it into a map

--- a/test/state_flow/test_helpers.clj
+++ b/test/state_flow/test_helpers.clj
@@ -1,5 +1,6 @@
 (ns state-flow.test-helpers
   (:require [state-flow.core]
+            [state-flow.cljtest :as cljtest]
             [state-flow.state :as state]))
 
 (defmacro this-line-number
@@ -58,3 +59,8 @@
                                                    node#))))
       :flow-ret    (first res#)
       :flow-state  (second res#)}))
+
+(defmacro defflow+report
+  [forms]
+  `(binding [*out* (clojure.java.io/writer (java.io.File/createTempFile "test" "log"))]
+     (cljtest/defflow ~@forms)))

--- a/test/state_flow/test_helpers.clj
+++ b/test/state_flow/test_helpers.clj
@@ -1,6 +1,6 @@
 (ns state-flow.test-helpers
-  (:require [state-flow.core]
-            [state-flow.cljtest :as cljtest]
+  (:require [state-flow.cljtest :as cljtest]
+            [state-flow.core]
             [state-flow.state :as state]))
 
 (defmacro this-line-number


### PR DESCRIPTION
addresses #66 

What was done:
* match? now saves test report as metadata for each test done with match?
* instead of making a clojure.test assertion with match?, instead we make the assertions on `defflow` macro by calling `clojure.test/report` with the test report metadata that we gathered after the flow is run. This approach was used to preserve line and file information from when the assertion was made.

This way we are decoupling "making assertions" from reporting them.

To plugin other test frameworks and/or test runners, all that is needed is for the tool to gather and understand state-flow test report metadata.

Other "asserters" different from `match?` can be theoretically made as long as they push their report to metadata following our data structure (which is still internal/subject to change for the moment)

TODO:
* Create a spec for the report data structure