### PR TITLE
match? -> expect

### DIFF
--- a/dev/state_flow/rewrite/match_to_expect.clj
+++ b/dev/state_flow/rewrite/match_to_expect.clj
@@ -1,0 +1,71 @@
+(ns state-flow.rewrite.match-to-expect
+  (:require [clojure.java.io :as io]
+            [rewrite-clj.zip :as z]))
+
+(def cljtest-test-src
+  (delay (z/of-file "test/state_flow/cljtest_test.clj")))
+
+(def data "(state-flow/run (cljtest/match? \"DESC\" 'actual 'expected) {:initial :state})")
+
+(def ^:dynamic *match?-symbol* 'match?)
+(def ^:dynamic *expect-symbol* 'expect)
+
+(defn match?->expect
+  "Given a match? expression e.g.
+
+    (match? <description> <actual> <expected>)
+    ;; or
+    (match? <description> <actual> <expected> <params>)
+
+  Returns an expect expression e.g.
+
+    (expect <expected> <actual>)
+    ;; or
+    (expect <expected> <actual> <params>)
+
+  If there is an exception, printlns the expression so you can
+  find and handle it manually."
+  [expect-sym match-exp]
+  (try
+    (let [match-sym (-> match-exp z/down)
+          actual (-> match-sym
+                     z/right
+                     z/right)
+          expected (-> actual z/right)]
+      (-> match-sym
+          (z/replace expect-sym)
+          z/right
+          z/remove
+          z/right
+          (z/replace (z/node expected))
+          z/right
+          (z/replace (z/node actual))))
+    (catch Exception e
+      (println "Error processing " (z/string match-exp))
+      match-exp)))
+
+(defn match?-expr? [match?-sym node]
+  (when (= :list (z/tag node))
+    (when-let [op (z/down node)]
+      (= match?-sym (z/value op)))))
+
+(defn rewrite-match?->expect [match?-sym expect-sym path]
+  (let [data (z/of-file path)]
+    (spit (io/file path)
+          (z/root-string
+           (loop [data data]
+             (let [updated (try
+                             (z/prewalk data
+                                        (partial match?-expr? match?-sym)
+                                        (partial match?->expect expect-sym))
+                             (catch Exception _ data))]
+               (if (z/rightmost? updated)
+                 updated
+                 (recur (z/right updated)))))))))
+
+(comment
+  (rewrite-match?->expect 'cljtest/match?
+                          'cljtest/expect
+                          "test/state_flow/cljtest_test.clj")
+
+  )

--- a/project.clj
+++ b/project.clj
@@ -29,7 +29,8 @@
                    :dependencies [[ns-tracker "0.4.0"]
                                   [org.clojure/tools.namespace "0.3.1"]
                                   [midje "1.9.9"]
-                                  [org.clojure/java.classpath "0.3.0"]]}}
+                                  [org.clojure/java.classpath "0.3.0"]
+                                  [rewrite-clj "0.6.1"]]}}
 
   :aliases {"coverage" ["cloverage" "-s" "coverage"]
             "lint"     ["do" ["cljfmt" "check"] ["nsorg"]]

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -75,19 +75,24 @@
   [s]
   (-> s meta :top-level-description))
 
-(defmacro flow
-  "Defines a flow"
-  {:style/indent :defn}
-  [description & flows]
+(defn flow* [{:keys [description caller-meta]} & flows]
   (when-not (string-expr? description)
-     (throw (IllegalArgumentException. "The first argument to flow must be a description string")))
-  (let [flow-meta (meta &form)
+    (throw (IllegalArgumentException. "The first argument to flow must be a description string")))
+  (let [flow-meta caller-meta
         flows'    (or flows `[(m/return nil)])]
     `(m/do-let
       (push-meta ~description ~flow-meta)
       [ret# (m/do-let ~@flows')]
       (pop-meta)
       (m/return ret#))))
+
+(defmacro flow
+  "Defines a flow"
+  {:style/indent :defn}
+  [description & flows]
+  (apply flow* {:description description
+                :caller-meta (meta &form)}
+         flows))
 
 (defn run
   "Given an initial-state (default {}), runs a flow and returns a pair of

--- a/src/state_flow/probe.clj
+++ b/src/state_flow/probe.clj
@@ -12,20 +12,20 @@
 (defn ^:private retry
   "Tries at most n times, returns a vector with true and first element that succeeded
   or false and result of the first try"
-  [times pred? lazy-seq]
-  (let [remaining (drop-while (complement pred?) (take times lazy-seq))]
+  [times-to-try check-fn tries]
+  (let [remaining (drop-while (complement check-fn) (take times-to-try tries))]
     (if (empty? remaining)
-      [false (first lazy-seq)]
+      [false (first tries)]
       [true  (first remaining)])))
 
 (defn probe
   "evaluates state repeatedly with check-fn until check-fn succeeds or we try too many times"
   ([state check-fn]
-   (probe state check-fn {:sleep-time default-sleep-time :times-to-try default-times-to-try}))
+   (probe state check-fn {}))
   ([state check-fn {:keys [sleep-time times-to-try]
                     :or   {sleep-time   default-sleep-time
                            times-to-try default-times-to-try}}]
    (m/mlet [world (state/get)
-            :let [runs   (repeatedly #(do (Thread/sleep sleep-time) (state/eval state world)))
-                  result (retry times-to-try check-fn runs)]]
+            :let [tries  (repeatedly #(do (Thread/sleep sleep-time) (state/eval state world)))
+                  result (retry times-to-try check-fn tries)]]
      (state/return result))))

--- a/test/state_flow/cljtest_test.clj
+++ b/test/state_flow/cljtest_test.clj
@@ -9,7 +9,7 @@
 
 (def get-value-state (state/gets (comp deref :value)))
 
-(deftest test-match?
+(deftest test-expect
   (testing "passing cases"
     (testing "with literals for expected and actual"
       (let [[ret state] (state-flow/run (cljtest/expect 3 3) {:initial :state})]
@@ -54,7 +54,7 @@
              (flow "flow"
                (test-helpers/delayed-add-two 100)
                (cljtest/expect 2 get-value-state {:times-to-try 2
-                                                      :sleep-time 75}))
+                                                  :sleep-time 75}))
              {:value (atom 0)})]
         (testing "returns actual (derived from state)"
           (is (= 2 flow-ret)))
@@ -87,7 +87,7 @@
                          :matcher-combinators.result/weight 1}]]
                       (-> flow-state meta :match-results))))
         (testing "reports match-results to clojure.test"
-          (testing "including the line number where match? was called"
+          (testing "including the line number where expect was called"
             (= (+ three-lines-before-call-to-match 3) (:line report-data)))
           (is (match? {:matcher-combinators.result/type  :mismatch
                        :matcher-combinators.result/value {:n {:expected 1 :actual 2}}}
@@ -99,7 +99,7 @@
              (flow "flow"
                (test-helpers/delayed-add-two 200)
                (cljtest/expect 2 get-value-state {:times-to-try 2
-                                                      :sleep-time 75}))
+                                                  :sleep-time 75}))
              {:value (atom 0)})]
         (testing "returns actual (derived from state)"
           (is (= 0 flow-ret)))

--- a/test/state_flow/cljtest_test.clj
+++ b/test/state_flow/cljtest_test.clj
@@ -10,87 +10,109 @@
 (def get-value-state (state/gets (comp deref :value)))
 
 (deftest test-match?
-  (testing "doesn't change state"
-    (let [[ret state] (state-flow/run (cljtest/match? "test-1" test-helpers/add-two 3) {:value 1})]
-      (is (= 3 ret))
-      (is (= 1 (:value state)))))
+  (testing "passing cases"
+    (testing "with literals for expected and actual"
+      (let [[ret state] (state-flow/run (cljtest/match? "DESC" 3 3) {:initial :state})]
+        (testing "returns actual (literal)"
+          (is (= 3 ret)))
+        (testing "doesn't change state"
+          (is (= {:initial :state} state)))
+        (testing "provides match-results on meta"
+          (is (match? [[{:matcher-combinators.result/type   :match
+                         :matcher-combinators.result/value  3
+                         :matcher-combinators.result/weight 0}]]
+                      (-> state meta :match-results))))))
 
-  (testing "works with non-state values"
-    (let [[ret state] (state-flow/run (cljtest/match? "test-2" 3 3) {})]
-      (is (= 3 ret))
-      (is (= {} state))))
+    (testing "with state monad for actual"
+      (let [[ret state] (state-flow/run (cljtest/match? "DESC" test-helpers/add-two 3) {:value 1})]
+        (testing "returns actual (derived from state)"
+          (is (= 3 ret)))
+        (testing "doesn't change state"
+          (is (= {:value 1} state)))
+        (testing "provides match-results on meta"
+          (is (match? [[{:matcher-combinators.result/type   :match
+                         :matcher-combinators.result/value  3
+                         :matcher-combinators.result/weight 0}]]
+                      (-> state meta :match-results))))))
 
-  (testing "works with matcher combinators (embeds by default)"
-    (let [[ret state] (state-flow/run
-                        (cljtest/match? "contains with monadic left value"
-                                        (state/gets :value)
-                                        {:a 2})
-                        {:value {:a 2 :b 5}})]
-      (is (= {:a 2 :b 5} ret))
-      (is (= {:a 2 :b 5} (:value state)))))
+    (testing "with explicit matcher for expected"
+      (let [[ret state] (state-flow/run (cljtest/match? "DESC"
+                                                        test-helpers/add-two
+                                                        (matchers/equals 3)) {:value 1})]
+        (testing "returns actual (derived from state)"
+          (is (= 3 ret)))
+        (testing "doesn't change state"
+          (is (= {:value 1} state)))
+        (testing "provides match-results on meta"
+          (is (match? [[{:matcher-combinators.result/type   :match
+                         :matcher-combinators.result/value  3
+                         :matcher-combinators.result/weight 0}]]
+                      (-> state meta :match-results))))))
 
-  (testing "works with matcher combinators equals"
-    (let [[ret state] (state-flow/run
-                        (cljtest/match? "contains with monadic left value"
-                                        (state/gets :value)
-                                        (matchers/equals {:a 2 :b 5}))
-                        {:value {:a 2 :b 5}})]
-      (is (= {:a 2 :b 5} ret))
-      (is (= {:a 2 :b 5} (:value state)))))
+    (testing "forcing probe to try more than once"
+      (let [{:keys [flow-ret flow-state]}
+            (test-helpers/run-flow
+             (flow "flow"
+               (test-helpers/delayed-add-two 100)
+               (cljtest/match? "2" get-value-state 2 {:times-to-try 2
+                                                      :sleep-time 75}))
+             {:value (atom 0)})]
+        (testing "returns actual (derived from state)"
+          (is (= 2 flow-ret)))
+        (testing "match-results include mismatch then match"
+          (is (match? [[{:matcher-combinators.result/type :mismatch
+                         :matcher-combinators.result/value {:expected 2 :actual 0}
+                         :matcher-combinators.result/weight 1}
+                        {:matcher-combinators.result/type :match
+                         :matcher-combinators.result/value 2
+                         :matcher-combinators.result/weight 0}]]
+                      (-> flow-state meta :match-results)))))))
 
   (testing "failure case"
-    (let [{:keys [flow-ret flow-state]}
-          (test-helpers/run-flow (cljtest/match? "contains with monadic left value"
-                                                 (state/gets :value)
-                                                 (matchers/equals {:a 1 :b 5}))
-                                 {:value {:a 2 :b 5}})]
-      (is (= {:a 2 :b 5} flow-ret))
-      (is (= {:a 2 :b 5} (:value flow-state)))))
+    (testing "with probe result that never changes"
+      (let [{:keys [flow-ret flow-state report-data]}
+            (test-helpers/run-flow (cljtest/match? "contains with monadic left value"
+                                                   (state/gets :value)
+                                                   (matchers/equals {:n 1})
+                                                   {:times-to-try 2})
+                                   {:value {:n 2}})]
+        (testing "returns actual"
+          (is (= {:n 2} flow-ret)))
+        (testing "provides match-results on meta"
+          (is (match? [[{:matcher-combinators.result/type   :mismatch
+                         :matcher-combinators.result/value  {:n {:expected 1 :actual 2}}
+                         :matcher-combinators.result/weight 1}
+                        {:matcher-combinators.result/type   :mismatch
+                         :matcher-combinators.result/value  {:n {:expected 1 :actual 2}}
+                         :matcher-combinators.result/weight 1}]]
+                      (-> flow-state meta :match-results))))
+        (testing "reports match-results to clojure.test"
+          (is (match? {:matcher-combinators.result/type  :mismatch
+                       :matcher-combinators.result/value {:n {:expected 1 :actual 2}}}
+                      (-> report-data :actual :match-result))))))
 
-  (testing "add two with small delay"
-    (let [state  {:value (atom 0)}
-          {:keys [flow-ret]}
-          (test-helpers/run-flow
-           (flow "flow"
-             (test-helpers/delayed-add-two 100)
-             (cljtest/match? "2" get-value-state 2))
-           state)]
-      (is (= 2 flow-ret))))
-
-  (testing "we can tweak timeout and times to try"
-    (let [state  {:value (atom 0)}
-          {:keys [report-data flow-ret flow-state]}
-          (test-helpers/run-flow
-           (flow "flow"
-             (test-helpers/delayed-add-two 100)
-             (cljtest/match? "2" get-value-state 2 {:sleep-time   0
-                                                    :times-to-try 1}))
-           state)]
-      (is (match? {:matcher-combinators.result/type :mismatch
-                   :matcher-combinators.result/value {:expected 2 :actual 0}}
-                  (-> report-data :actual :match-result)))
-      (is (= 0 flow-ret))))
-
-  (testing "add two with too much delay (timeout)"
-    (let [state  {:value (atom 0)}
-          {:keys [report-data flow-ret flow-state]}
-          (test-helpers/run-flow
-           (flow "flow"
-             (test-helpers/delayed-add-two 4000)
-             (cljtest/match? "2" get-value-state 2))
-           state)]
-      (is (match? {:matcher-combinators.result/type :mismatch
-                   :matcher-combinators.result/value {:expected 2 :actual 0}}
-                  (-> report-data :actual :match-result)))
-      (is (= 0 flow-ret))))
-
-  (testing "works with matcher combinators in any order"
-    (let [val {:value [1 2 3]}
-          {:keys [flow-state]}
-          (test-helpers/run-flow (cljtest/match? "contains with monadic left value"
-                                                 (state/gets :value)
-                                                 (matchers/in-any-order [1 3 2])) val)]
-      (is (match? {:value [1 2 3]} flow-state)))))
+    (testing "with probe result that only changes after timeout"
+      (let [{:keys [flow-ret flow-state report-data]}
+            (test-helpers/run-flow
+             (flow "flow"
+               (test-helpers/delayed-add-two 200)
+               (cljtest/match? "2" get-value-state 2 {:times-to-try 2
+                                                      :sleep-time 75}))
+             {:value (atom 0)})]
+        (testing "returns actual (derived from state)"
+          (is (= 0 flow-ret)))
+        (testing "match-results include mismatch then match"
+          (is (match? [[{:matcher-combinators.result/type :mismatch
+                         :matcher-combinators.result/value {:expected 2 :actual 0}
+                         :matcher-combinators.result/weight 1}
+                        {:matcher-combinators.result/type :mismatch
+                         :matcher-combinators.result/value {:expected 2 :actual 0}
+                         :matcher-combinators.result/weight 1}]]
+                      (-> flow-state meta :match-results))))
+        (testing "reports match-results to clojure.test"
+          (is (match? {:matcher-combinators.result/type  :mismatch
+                       :matcher-combinators.result/value {:expected 2 :actual 0}}
+                      (-> report-data :actual :match-result))))))))
 
 ;; TODO:(dchelimsky,2019-12-27) I do not understand why, but inlining these expansions
 ;; in the deftest below causes test failures. I think it has to do with calling macroexpand

--- a/test/state_flow/cljtest_test.clj
+++ b/test/state_flow/cljtest_test.clj
@@ -129,8 +129,8 @@
   (macroexpand-1 '(defflow my-flow {:init (constantly {:value 1
                                                        :map {:a 1 :b 2}})}
                     [value (state/gets :value)]
-                    (cljtest/match? value 1)
-                    (cljtest/match? (state/gets :map) {:b 2}))))
+                    (cljtest/match? "" value 1)
+                    (cljtest/match? "" (state/gets :map) {:b 2}))))
 
 (deftest test-defflow
   (testing "defines flow with default parameters"
@@ -157,8 +157,8 @@
                 (state-flow.core/flow
                   "my-flow"
                   [value (state/gets :value)]
-                  (cljtest/match? value 1)
-                  (cljtest/match? (state/gets :map) {:b 2}))))
+                  (cljtest/match? "" value 1)
+                  (cljtest/match? "" (state/gets :map) {:b 2}))))
            flow-with-binding-and-match))))
 
 (defflow my-flow {:init (constantly {:value 1

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -1,7 +1,7 @@
 (ns state-flow.core-test
   (:require [clojure.test :as t :refer [deftest testing is]]
             [matcher-combinators.test :refer [match?]]
-            [state-flow.test-helpers :as test-helpers]
+            [state-flow.test-helpers :as test-helpers :refer [this-line-number]]
             [state-flow.core :as state-flow :refer [flow]]
             [state-flow.state :as state]))
 
@@ -117,10 +117,6 @@
   (let [add-two-fn (state-flow/as-step-fn (state/modify #(+ 2 %)))]
     (is (= 3 (add-two-fn 1)))))
 
-(defmacro line-number-of-call-site []
-  (let [m (meta &form)]
-    `(:line ~m)))
-
 (defn consecutive?
   "Returns true iff ns (minimum of 2) all increase by 1"
   [& ns]
@@ -144,7 +140,7 @@
     ;; WARNING: this (admittedly brittle) test depends on the following 4 lines
     ;; staying in sequence. They can move up or down in this file together,
     ;; but re-order them at your own peril.
-    (let [line-number-before-flow-invocation (line-number-of-call-site)
+    (let [line-number-before-flow-invocation (this-line-number)
           [desc] (state-flow/run (flow "level 1"
                                    (flow "level 2"
                                      (flow "level 3"
@@ -164,7 +160,7 @@
                             level-3-line))))))
 
   (testing "composition"
-    (let [line-number-before-flow-invocation (line-number-of-call-site)
+    (let [line-number-before-flow-invocation (this-line-number)
           level-3  (flow "level 3" (state-flow/current-description))
           level-2  (flow "level 2" level-3)
           level-1  (flow "level 1" level-2)

--- a/test/state_flow/test_helpers.clj
+++ b/test/state_flow/test_helpers.clj
@@ -2,6 +2,12 @@
   (:require [state-flow.core]
             [state-flow.state :as state]))
 
+(defmacro this-line-number
+  "Returns the line number of the call site."
+  []
+  (let [m (meta &form)]
+    `(:line ~m)))
+
 (def get-value (comp deref :value))
 (def get-value-state (state/gets get-value))
 


### PR DESCRIPTION
This PR represents a proposal for how to deal with the argument ordering of `match?`: deprecate it and introduce a new `expect` function e.g.

```clojure
(expect <expected> <actual> <optional-params>)
```

In addition to introducing the function, this PR also includes a rudimentary rewrite script which was used to convert `match?` to `expect` in the `cljtest_test` namespace.

NOTE: this is initially based off the `dc/add-match-results-to-state-meta` branch, which is the PR branch for #70. That should be merged first.