### PR TITLE
Helper for cljtest

### DIFF
--- a/src/state_flow/labs/cljtest.clj
+++ b/src/state_flow/labs/cljtest.clj
@@ -1,11 +1,18 @@
 (ns state-flow.labs.cljtest
   (:require [state-flow.core :as core]
             [state-flow.state :as state]
-            [clojure.test :as ctest]))
+            [clojure.test :as ctest]
+            matcher-combinators.clj-test))
+
+(defmacro testing-with {:style/indent :defn}
+  [desc bindings & body]
+  "Just like `testing`, but with bindings that are only accessible during test"
+  `(core/flow ~desc
+     [full-desc# (core/current-description)]
+     ~bindings
+     (state/wrap-fn #(do ~(with-meta `(ctest/testing ~desc ~@body)
+                            (meta &form))))))
 
 (defmacro testing [desc & body]
   "state-flow's equivalent to clojure test's `testing`"
-  `(core/flow ~desc
-              [full-desc# (core/current-description)]
-              (state/wrap-fn #(do ~(with-meta `(ctest/testing ~desc ~@body)
-                                     (meta &form))))))
+  `(testing-with ~desc [] ~@body))

--- a/test/state_flow/labs/cljtest_test.clj
+++ b/test/state_flow/labs/cljtest_test.clj
@@ -6,14 +6,51 @@
             [state-flow.core :as state-flow]
             [state-flow.state :as state]))
 
-(deftest testing-macro
-  (testing "works for failure cases"
-    (let [{:keys [flow-ret flow-state]}
-          (test-helpers/run-flow (state-flow/flow "desc"
-                                   [v (state/gets :value)]
-                                   (labs.cljtest/testing "contains with monadic left value"
-                                     (is (= {:a 1 :b 5} v))))
-                                 {:value {:a 2 :b 5}})]
-      (is (false? flow-ret))
-      (is (match? {:value {:a 2 :b 5}}
-                  flow-state)))))
+(def inc-b (state/modify #(update-in % [:value :b] inc)))
+
+(def sample-flow
+  (state-flow/flow "desc"
+    inc-b
+    [v (state/gets :value)]
+    (labs.cljtest/testing-with "contains with monadic left value"
+      [expected (state/return {:a 1 :b 5})]
+      (is (= expected v)))))
+
+
+(deftest testing-with-macro
+  (testing "bindings are available during test"
+    (is (true? (-> (state-flow/flow "desc"
+                     (labs.cljtest/testing-with "testing with bindings"
+                       [a (state/return 1)]
+                       (is (= a 1))))
+                   (test-helpers/run-flow {})
+                   :flow-ret))))
+
+  (testing "bindings are not available after test"
+    (is (= 0 (-> (state-flow/flow "desc"
+                   [a (state/return 0)]
+                   (labs.cljtest/testing-with "testing with bindings"
+                     [a (state/return 1)]
+                     (is (= a 1)))
+                   (state/return a))
+                 (test-helpers/run-flow {})
+                 :flow-ret))))
+
+  (testing "returns test result"
+    (is (true? (->> {:value {:a 1 :b 4}}
+                    (test-helpers/run-flow sample-flow)
+                    :flow-ret)))
+    (is (false? (->> {:value {:a 1 :b 3}}
+                     (test-helpers/run-flow sample-flow)
+                     :flow-ret))))
+
+  (testing "preserves flow state"
+    (is (match? {:value {:a 1 :b 5}}
+                (->> {:value {:a 1 :b 4}}
+                     (test-helpers/run-flow sample-flow)
+                     :flow-state)))
+
+    (is (match? {:value {:a 1 :b 8}}
+                (->> {:value {:a 1 :b 7}}
+                     (test-helpers/run-flow sample-flow)
+                     :flow-state)))))


### PR DESCRIPTION
PoC for discussion on `cljtest/match?`. This might not reduce boilerplate needed for bindings, but at least makes it more clear that binding results are being "unwrapped" and don't pollute the rest of the flow with unnecessary bindings.