### PR TITLE
refactor match?

### DIFF
--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -20,26 +20,30 @@
 (defmethod clojure.pprint/simple-dispatch cats.monad.exception.Failure [f]
   (pr f))
 
+(defn modify-meta
+  "Returns a monad that will apply vary-meta to the world.
+
+  For internal use. Subject to change."
+  [f & args]
+  (state/modify (fn [s] (apply vary-meta s f args))))
+
 (defn push-meta
   "Returns a flow that will modify the state metadata.
 
   For internal use. Subject to change."
   [description {:keys [line]}]
-  (state/modify
-   (fn [s]
-     (-> s
-         (vary-meta update :top-level-description #(or % description))
-         (vary-meta update :description-stack (fnil conj []) (str description
-                                                                  (when line
-                                                                    (format " (line %s)" line))))))))
+  (modify-meta
+   (fn [m] (-> m
+               (update :top-level-description #(or % description))
+               (update :description-stack (fnil conj []) (str description
+                                                              (when line
+                                                                (format " (line %s)" line))))))))
 
-(def pop-meta
+(defn pop-meta []
   "Returns a flow that will modify the state metadata.
 
   For internal use. Subject to change."
-  (state/modify
-   (fn [s]
-     (vary-meta s update :description-stack pop))))
+  (modify-meta update :description-stack pop))
 
 (defn ^:private format-description
   [strs]
@@ -71,19 +75,24 @@
   [s]
   (-> s meta :top-level-description))
 
-(defmacro flow
-  "Defines a flow"
-  {:style/indent :defn}
-  [description & flows]
+(defn flow* [{:keys [description caller-meta]} & flows]
   (when-not (string-expr? description)
-     (throw (IllegalArgumentException. "The first argument to flow must be a description string")))
-  (let [flow-meta (meta &form)
+    (throw (IllegalArgumentException. "The first argument to flow must be a description string")))
+  (let [flow-meta caller-meta
         flows'    (or flows `[(m/return nil)])]
     `(m/do-let
       (push-meta ~description ~flow-meta)
       [ret# (m/do-let ~@flows')]
-      pop-meta
+      (pop-meta)
       (m/return ret#))))
+
+(defmacro flow
+  "Defines a flow"
+  {:style/indent :defn}
+  [description & flows]
+  (apply flow* {:description description
+                :caller-meta (meta &form)}
+         flows))
 
 (defn run
   "Given an initial-state (default {}), runs a flow and returns a pair of

--- a/src/state_flow/probe.clj
+++ b/src/state_flow/probe.clj
@@ -12,20 +12,20 @@
 (defn ^:private retry
   "Tries at most n times, returns a vector with true and first element that succeeded
   or false and result of the first try"
-  [times pred? lazy-seq]
-  (let [remaining (drop-while (complement pred?) (take times lazy-seq))]
+  [times-to-try check-fn tries]
+  (let [remaining (drop-while (complement check-fn) (take times-to-try tries))]
     (if (empty? remaining)
-      [false (first lazy-seq)]
+      [false (first tries)]
       [true  (first remaining)])))
 
 (defn probe
   "evaluates state repeatedly with check-fn until check-fn succeeds or we try too many times"
   ([state check-fn]
-   (probe state check-fn {:sleep-time default-sleep-time :times-to-try default-times-to-try}))
+   (probe state check-fn {}))
   ([state check-fn {:keys [sleep-time times-to-try]
                     :or   {sleep-time   default-sleep-time
                            times-to-try default-times-to-try}}]
    (m/mlet [world (state/get)
-            :let [runs   (repeatedly #(do (Thread/sleep sleep-time) (state/eval state world)))
-                  result (retry times-to-try check-fn runs)]]
+            :let [tries  (repeatedly #(do (Thread/sleep sleep-time) (state/eval state world)))
+                  result (retry times-to-try check-fn tries)]]
      (state/return result))))

--- a/test/state_flow/cljtest_test.clj
+++ b/test/state_flow/cljtest_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :as t :refer [deftest testing is]]
             [matcher-combinators.test :refer [match?]]
             [matcher-combinators.matchers :as matchers]
-            [state-flow.test-helpers :as test-helpers]
+            [state-flow.test-helpers :as test-helpers :refer [this-line-number]]
             [state-flow.cljtest :as cljtest :refer [defflow]]
             [state-flow.core :as state-flow :refer [flow]]
             [state-flow.state :as state]))
@@ -10,87 +10,74 @@
 (def get-value-state (state/gets (comp deref :value)))
 
 (deftest test-match?
-  (testing "doesn't change state"
-    (let [[ret state] (state-flow/run (cljtest/match? "test-1" test-helpers/add-two 3) {:value 1})]
-      (is (= 3 ret))
-      (is (= 1 (:value state)))))
+  (testing "passing cases"
+    (testing "with literals for expected and actual"
+      (let [[ret state] (state-flow/run (cljtest/match? "DESC" 3 3) {:initial :state})]
+        (testing "returns actual (literal)"
+          (is (= 3 ret)))
+        (testing "doesn't change state"
+          (is (= {:initial :state} state)))))
 
-  (testing "works with non-state values"
-    (let [[ret state] (state-flow/run (cljtest/match? "test-2" 3 3) {})]
-      (is (= 3 ret))
-      (is (= {} state))))
+    (testing "with state monad for actual"
+      (let [[ret state] (state-flow/run (cljtest/match? "DESC" test-helpers/add-two 3) {:value 1})]
+        (testing "returns actual (derived from state)"
+          (is (= 3 ret)))
+        (testing "doesn't change state"
+          (is (= {:value 1} state)))))
 
-  (testing "works with matcher combinators (embeds by default)"
-    (let [[ret state] (state-flow/run
-                        (cljtest/match? "contains with monadic left value"
-                                        (state/gets :value)
-                                        {:a 2})
-                        {:value {:a 2 :b 5}})]
-      (is (= {:a 2 :b 5} ret))
-      (is (= {:a 2 :b 5} (:value state)))))
+    (testing "with explicit matcher for expected"
+      (let [[ret state] (state-flow/run (cljtest/match? "DESC"
+                                                        test-helpers/add-two
+                                                        (matchers/equals 3)) {:value 1})]
+        (testing "returns actual (derived from state)"
+          (is (= 3 ret)))
+        (testing "doesn't change state"
+          (is (= {:value 1} state)))))
 
-  (testing "works with matcher combinators equals"
-    (let [[ret state] (state-flow/run
-                        (cljtest/match? "contains with monadic left value"
-                                        (state/gets :value)
-                                        (matchers/equals {:a 2 :b 5}))
-                        {:value {:a 2 :b 5}})]
-      (is (= {:a 2 :b 5} ret))
-      (is (= {:a 2 :b 5} (:value state)))))
+    (testing "forcing probe to try more than once"
+      (let [{:keys [flow-ret flow-state]}
+            (test-helpers/run-flow
+             (flow "flow"
+               (test-helpers/delayed-add-two 100)
+               (cljtest/match? "2" get-value-state 2 {:times-to-try 2
+                                                      :sleep-time 75}))
+             {:value (atom 0)})]
+        (testing "returns actual (derived from state)"
+          (is (= 2 flow-ret))))))
 
   (testing "failure case"
-    (let [{:keys [flow-ret flow-state]}
-          (test-helpers/run-flow (cljtest/match? "contains with monadic left value"
-                                                 (state/gets :value)
-                                                 (matchers/equals {:a 1 :b 5}))
-                                 {:value {:a 2 :b 5}})]
-      (is (= {:a 2 :b 5} flow-ret))
-      (is (= {:a 2 :b 5} (:value flow-state)))))
+    (testing "with probe result that never changes"
+      (let [three-lines-before-call-to-match (this-line-number)
+            {:keys [flow-ret flow-state report-data]}
+            (test-helpers/run-flow
+             (cljtest/match? "contains with monadic left value"
+                             (state/gets :value)
+                             (matchers/equals {:n 1})
+                             {:times-to-try 2})
+             {:value {:n 2}})]
+        (testing "returns actual"
+          (is (= {:n 2} flow-ret)))
+        (testing "reports match-results to clojure.test"
+          (testing "including the line number where match? was called"
+            (= (+ three-lines-before-call-to-match 3) (:line report-data)))
+          (is (match? {:matcher-combinators.result/type  :mismatch
+                       :matcher-combinators.result/value {:n {:expected 1 :actual 2}}}
+                      (-> report-data :actual :match-result))))))
 
-  (testing "add two with small delay"
-    (let [state  {:value (atom 0)}
-          {:keys [flow-ret]}
-          (test-helpers/run-flow
-           (flow "flow"
-             (test-helpers/delayed-add-two 100)
-             (cljtest/match? "2" get-value-state 2))
-           state)]
-      (is (= 2 flow-ret))))
-
-  (testing "we can tweak timeout and times to try"
-    (let [state  {:value (atom 0)}
-          {:keys [report-data flow-ret flow-state]}
-          (test-helpers/run-flow
-           (flow "flow"
-             (test-helpers/delayed-add-two 100)
-             (cljtest/match? "2" get-value-state 2 {:sleep-time   0
-                                                    :times-to-try 1}))
-           state)]
-      (is (match? {:matcher-combinators.result/type :mismatch
-                   :matcher-combinators.result/value {:expected 2 :actual 0}}
-                  (-> report-data :actual :match-result)))
-      (is (= 0 flow-ret))))
-
-  (testing "add two with too much delay (timeout)"
-    (let [state  {:value (atom 0)}
-          {:keys [report-data flow-ret flow-state]}
-          (test-helpers/run-flow
-           (flow "flow"
-             (test-helpers/delayed-add-two 4000)
-             (cljtest/match? "2" get-value-state 2))
-           state)]
-      (is (match? {:matcher-combinators.result/type :mismatch
-                   :matcher-combinators.result/value {:expected 2 :actual 0}}
-                  (-> report-data :actual :match-result)))
-      (is (= 0 flow-ret))))
-
-  (testing "works with matcher combinators in any order"
-    (let [val {:value [1 2 3]}
-          {:keys [flow-state]}
-          (test-helpers/run-flow (cljtest/match? "contains with monadic left value"
-                                                 (state/gets :value)
-                                                 (matchers/in-any-order [1 3 2])) val)]
-      (is (match? {:value [1 2 3]} flow-state)))))
+    (testing "with probe result that only changes after timeout"
+      (let [{:keys [flow-ret flow-state report-data]}
+            (test-helpers/run-flow
+             (flow "flow"
+               (test-helpers/delayed-add-two 200)
+               (cljtest/match? "2" get-value-state 2 {:times-to-try 2
+                                                      :sleep-time 75}))
+             {:value (atom 0)})]
+        (testing "returns actual (derived from state)"
+          (is (= 0 flow-ret)))
+        (testing "reports match-results to clojure.test"
+          (is (match? {:matcher-combinators.result/type  :mismatch
+                       :matcher-combinators.result/value {:expected 2 :actual 0}}
+                      (-> report-data :actual :match-result))))))))
 
 ;; TODO:(dchelimsky,2019-12-27) I do not understand why, but inlining these expansions
 ;; in the deftest below causes test failures. I think it has to do with calling macroexpand

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -1,7 +1,7 @@
 (ns state-flow.core-test
   (:require [clojure.test :as t :refer [deftest testing is]]
             [matcher-combinators.test :refer [match?]]
-            [state-flow.test-helpers :as test-helpers]
+            [state-flow.test-helpers :as test-helpers :refer [this-line-number]]
             [state-flow.core :as state-flow :refer [flow]]
             [state-flow.state :as state]))
 
@@ -117,10 +117,6 @@
   (let [add-two-fn (state-flow/as-step-fn (state/modify #(+ 2 %)))]
     (is (= 3 (add-two-fn 1)))))
 
-(defmacro line-number-of-call-site []
-  (let [m (meta &form)]
-    `(:line ~m)))
-
 (defn consecutive?
   "Returns true iff ns (minimum of 2) all increase by 1"
   [& ns]
@@ -144,7 +140,7 @@
     ;; WARNING: this (admittedly brittle) test depends on the following 4 lines
     ;; staying in sequence. They can move up or down in this file together,
     ;; but re-order them at your own peril.
-    (let [line-number-before-flow-invocation (line-number-of-call-site)
+    (let [line-number-before-flow-invocation (this-line-number)
           [desc] (state-flow/run (flow "level 1"
                                    (flow "level 2"
                                      (flow "level 3"
@@ -164,7 +160,7 @@
                             level-3-line))))))
 
   (testing "composition"
-    (let [line-number-before-flow-invocation (line-number-of-call-site)
+    (let [line-number-before-flow-invocation (this-line-number)
           level-3  (flow "level 3" (state-flow/current-description))
           level-2  (flow "level 2" level-3)
           level-1  (flow "level 1" level-2)

--- a/test/state_flow/test_helpers.clj
+++ b/test/state_flow/test_helpers.clj
@@ -2,6 +2,12 @@
   (:require [state-flow.core]
             [state-flow.state :as state]))
 
+(defmacro this-line-number
+  "Returns the line number of the call site."
+  []
+  (let [m (meta &form)]
+    `(:line ~m)))
+
 (def get-value (comp deref :value))
 (def get-value-state (state/gets get-value))
 


### PR DESCRIPTION
- extract flow* function so flow and match? can both provide line number information
  - before this, match was not showing it's line number information
- make pop-meta a fn to align w/ push-meta
- align names and remove redundant defaults
- refactor cljtest_test

NOTE: this is extracted from #70, the functionality of which is still being discussed/evaluated. This PR just includes the refactoring (no changes to behaviour).