### PR TITLE
Include line info for steps that raise exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.1.6]
+
+- Include line information when reporting flows that raise exceptions
+
 ## [2.1.5]
 
 - Make `state-flow.state/return` constructable/def'able outside monadic context.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,7 +174,6 @@ Changes were reintroduced in `2.2.4`, so use that.
 
 - Remove delay from the first try of `probe`
 - Refactor probe and change return value to include the probed value and check result of each try
->>>>>>> master
 
 ## [2.1.5]
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "2.1.5"
+(defproject nubank/state-flow "2.1.6"
   :description "Postman-like integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}

--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,7 @@
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [com.taoensso/timbre "4.10.0"]
                  [funcool/cats "2.3.3"]
-                 [nubank/matcher-combinators "1.2.7"]]
+                 [nubank/matcher-combinators "1.3.1"]]
 
   :exclusions   [log4j]
 

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -154,7 +154,7 @@
        (or (= 'flow (first expr))
            (= `flow (first expr)))))
 
-(defn annote-with-line-meta [flows]
+(defn annotate-with-line-meta [flows]
   (let [annotated-flows (reduce (fn [acc flow]
                                   (if (flow-expr? flow)
                                     (conj acc flow) ;; `flow`s push their own meta data
@@ -183,7 +183,7 @@
   (when (vector? (last flows))
     (throw (ex-info "The last argument to flow must be a flow/step, not a binding vector." {})))
   (let [flow-meta       caller-meta
-        annotated-flows (annote-with-line-meta
+        annotated-flows (annotate-with-line-meta
                          (or flows `[(m/return nil)]))
         pop-line-meta   (if (flow-expr? (last annotated-flows))
                           '()

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -87,9 +87,10 @@
     (str "`" short-expr "`")))
 
 (defn annote-with-line-meta [flows]
-  (let [subflow-lines (map (fn [f] `(push-meta ~(abbr-sexpr f)
-                                               ~(meta f)))
-                           flows)]
+  (when-let [subflow-lines (->> flows
+                                (map (fn [f] `(push-meta ~(abbr-sexpr f)
+                                                         ~(meta f))))
+                                seq)]
     (interleave subflow-lines
                 flows
                 (repeat `pop-meta))))

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -100,7 +100,7 @@
                                 seq)]
     (interleave subflow-lines
                 flows
-                (repeat `pop-meta))))
+                (repeat `(pop-meta)))))
 
 (defn flow* [{:keys [description caller-meta]} & flows]
   (when-not (string-expr? description)
@@ -111,7 +111,7 @@
                            `(m/return nil))]
     `(m/do-let
       (push-meta ~description ~flow-meta)
-      ~@but-last-flows
+      ~@(annote-with-line-meta but-last-flows)
       ~(push-abbr-meta last-flow)
       [ret# ~last-flow]
       (pop-meta)

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -3,7 +3,8 @@
   (:require [cats.core :as m]
             [cats.monad.exception :as e]
             [clojure.pprint :as pp]
-            [clojure.string :as str]
+            [clojure.string :as string]
+            [state-flow.internals.description :as description]
             [state-flow.state :as state]
             [taoensso.timbre :as log]))
 
@@ -31,15 +32,16 @@
   "Returns a flow that will modify the state metadata.
 
   For internal use. Subject to change."
-  [description {:keys [line ns file]}]
-  (modify-meta
-   (fn [m] (-> m
-               (update :top-level-description #(or % description))
-               (update :description-stack (fnil conj [])
-                       (cond-> {:description description
-                                :ns ns}
-                         line (assoc :line line)
-                         file (assoc :file file)))))))
+  [description {:keys [line ns file call-site-meta]}]
+  (let [meta-map (cond-> {:description description
+                          :ns          ns}
+                   call-site-meta (assoc :call-site-meta call-site-meta)
+                   line (assoc :line line)
+                   file (assoc :file file))]
+    (modify-meta
+     (fn [m] (-> m
+                 (update :top-level-description #(or % description))
+                 (update :description-stack (fnil conj []) meta-map))))))
 
 (defn pop-meta
   "Returns a flow that will modify the state metadata.
@@ -54,20 +56,41 @@
 
 (defn description->file
   [{:keys [file]}]
-  (when file (last (str/split file #"/"))))
+  (when file (last (string/split file #"/"))))
 
-(defn ^:private format-single-description
+(defn- format-single-description
   [{:keys [line description file] :as m}]
   (let [filename (description->file m)]
     (str description
          (when line
-           (format " (%s:%s)" filename line)))))
+           (if filename
+             (format " (%s:%s)" filename line)
+             ;; TODO: we can probably pull filename info from previous stack entries
+             (format " (line %s)" line))))))
+
+(defn- remove-non-terminal-call-site-meta
+  "non-terminal call-site meta is usually redudant with the meta-data provided
+  by `flow` forms.
+
+  It is thus mostly useful at the end of the call-stack, as a way to get more
+  precise line information for issues that arise after the last `flow` form."
+  [stack]
+  (let [call-site-meta?      #(contains? % :call-site-meta)
+        last-call-site-metas (->> stack
+                                  reverse
+                                  (take-while call-site-meta?)
+                                  reverse)
+        filtered-stack        (-> (remove call-site-meta? stack)
+                                  (concat last-call-site-metas))]
+    ;; `into` to preserve the `stack` sequence type
+    (into (empty stack) filtered-stack)))
 
 (defn format-description
   [stack]
   (->> stack
+       remove-non-terminal-call-site-meta
        (map format-single-description)
-       (str/join " -> ")))
+       (string/join " -> ")))
 
 (defn description-stack
   "Returns the list of descriptions in the current stack.
@@ -81,13 +104,13 @@
   [s]
   (-> s meta :description-stack))
 
-(defn ^:private string-expr? [x]
+(defn- string-expr? [x]
   (or (string? x)
       (and (sequential? x)
            (or (= (first x) 'str)
                (= (first x) 'clojure.core/str)))))
 
-(defn ^:private state->current-description [s]
+(defn- state->current-description [s]
   (-> (description-stack s)
       format-description))
 
@@ -121,32 +144,27 @@
    [hook (state/gets (comp :before-flow-hook meta))]
    (state/modify (or hook identity))))
 
-(def ^:private abbr-size 15)
-(defn ellipsify [expr-str]
-  (let [short-expr (subs expr-str 0 (- abbr-size 3))]
-    (case (first expr-str)
-      \( (str short-expr "...)")
-      \[ (str short-expr "...]")
-      (str short-expr "..."))))
+(defn- push-abbr-meta [flow]
+  `(push-meta ~(description/abbr-sexpr flow)
+              ~(assoc (meta flow)
+                      :call-site-meta true)))
 
-(defn abbr-sexpr [expr]
-  (let [expr-str   (str expr)
-        short-expr (if (< abbr-size (count expr-str))
-                     (ellipsify expr-str)
-                     expr-str)]
-    (str "`" short-expr "`")))
-
-(defn push-abbr-meta [flow]
-  `(push-meta ~(abbr-sexpr flow)
-              ~(meta flow)))
+(defn- flow-expr? [expr]
+  (and (coll? expr)
+       (or (= 'flow (first expr))
+           (= `flow (first expr)))))
 
 (defn annote-with-line-meta [flows]
-  (when-let [subflow-lines (->> flows
-                                (map push-abbr-meta)
-                                seq)]
-    (butlast (interleave subflow-lines
-                         flows
-                         (repeat `(pop-meta))))))
+  (let [annotated-flows (reduce (fn [acc flow]
+                                  (if (flow-expr? flow)
+                                    (conj acc flow) ;; `flow`s push their own meta data
+                                    (into [] (concat acc [(push-abbr-meta flow) flow `(pop-meta)]))))
+                                []
+                                flows)]
+    ;; to preserve the return value, exclude terminal pop-meta's
+    (if (= `(pop-meta) (last annotated-flows))
+      (butlast annotated-flows)
+      annotated-flows)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Public API
@@ -164,12 +182,17 @@
     (throw (IllegalArgumentException. "The first argument to flow must be a description string")))
   (when (vector? (last flows))
     (throw (ex-info "The last argument to flow must be a flow/step, not a binding vector." {})))
-  (let [flow-meta caller-meta
-        flows'    (or flows `[(m/return nil)])]
+  (let [flow-meta       caller-meta
+        annotated-flows (annote-with-line-meta
+                         (or flows `[(m/return nil)]))
+        pop-line-meta   (if (flow-expr? (last annotated-flows))
+                          '()
+                          `((pop-meta)))]
     `(m/do-let
       (push-meta ~description ~flow-meta)
       (apply-before-flow-hook)
-      [ret# (m/do-let ~@(annote-with-line-meta flows'))]
+      [ret# (m/do-let ~@annotated-flows)]
+      ~@pop-line-meta
       (pop-meta)
       (m/return ret#))))
 

--- a/src/state_flow/internals/description.clj
+++ b/src/state_flow/internals/description.clj
@@ -1,0 +1,22 @@
+(ns state-flow.internals.description
+  (:require [clojure.string :as string]))
+
+(def ^:private abbr-size 15)
+(defn- abbr-list [expr-str ellipse-end]
+  (let [[head & tail] (string/split expr-str #" ")]
+    (if (empty? tail)
+      expr-str
+      (str head ellipse-end))))
+
+(defn- ellipsify [expr-str]
+  (case (first expr-str)
+    \( (abbr-list expr-str " ...)")
+    \[ (abbr-list expr-str " ...]")
+    expr-str))
+
+(defn abbr-sexpr [expr]
+  (let [expr-str (str expr)]
+    (if (< abbr-size (count expr-str))
+      (ellipsify expr-str)
+      expr-str)))
+

--- a/test/state_flow/assertions/matcher_combinators_test.clj
+++ b/test/state_flow/assertions/matcher_combinators_test.clj
@@ -76,7 +76,7 @@
                      :match/actual       {:n 2}}
                     flow-ret)))
       (testing "saves assertion report to state with current description stack"
-        (is (match? {:flow/description-stack [{:description "match?"}]
+        (is (match? {:flow/description-stack [{:description "match?"} {:description "(cats.core/do-let ...)"}]
                      :match/result       :mismatch
                      :mismatch/detail    {:n {:expected 1 :actual 2}}
                      :probe/results      [{:check-result false :value {:n 2}}

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -161,11 +161,11 @@
 
 (deftest current-description
   (testing "top level flow"
-    (is (re-matches #"level 1 \(core_test.clj:\d+\)"
+    (is (re-matches #"level 1 \(core_test.clj:\d+\) -> \(state-flow\/current-description\) \(line \d+\)"
                     (first (state-flow/run (flow "level 1" (state-flow/current-description)))))))
 
   (testing "nested flows"
-    (is (re-matches #"level 1 \(core_test.clj:\d+\) -> level 2 \(core_test.clj:\d+\)"
+    (is (re-matches #"level 1 \(core_test.clj:\d+\) -> level 2 \(core_test.clj:\d+\) -> \(state-flow\/current-description\) \(line \d+\)"
                     (first (state-flow/run (flow "level 1"
                                              (flow "level 2"
                                                (state-flow/current-description)))))))
@@ -178,13 +178,14 @@
                                    (flow "level 2"
                                      (flow "level 3"
                                        (state-flow/current-description)))))]
-      (is (re-matches #"level 1 \(core_test.clj:\d+\) -> level 2 \(core_test.clj:\d+\) -> level 3 \(core_test.clj:\d+\)" desc))
+      (is (re-matches #"level 1 \(core_test.clj:\d+\) -> level 2 \(core_test.clj:\d+\) -> level 3 \(core_test.clj:\d+\) -> \(state-flow\/current-description\) \(line \d+\)"
+                      desc))
       (testing "line numbers are correct"
         (let [[level-1-line
                level-2-line
                level-3-line]
               (->> desc
-                   (re-find #"level 1 \(core_test.clj:(\d+)\) -> level 2 \(core_test.clj:(\d+)\) -> level 3 \(core_test.clj:(\d+)\)")
+                   (re-find #"level 1 \(core_test.clj:(\d+)\) -> level 2 \(core_test.clj:(\d+)\) -> level 3 \(core_test.clj:(\d+)\) -> \(state-flow\/current-description\) \(line \d+\)")
                    (drop 1)
                    (map #(Integer/parseInt %)))]
           (is (<= line-number-before-flow-invocation
@@ -198,7 +199,7 @@
           level-2  (flow "level 2" level-3)
           level-1  (flow "level 1" level-2)
           [desc _] (state-flow/run level-1)]
-      (is (re-matches #"level 1 \(core_test.clj:\d+\) -> level 2 \(core_test.clj:\d+\) -> level 3 \(core_test.clj:\d+\)"
+      (is (re-matches #"level 1 \(core_test.clj:\d+\) -> level 2 \(core_test.clj:\d+\) -> level 3 \(core_test.clj:\d+\) -> \(state-flow\/current-description\) \(line \d+\)"
                       desc))
       (testing "line numbers are correct, even when composed"
         (let [[level-1-line
@@ -215,16 +216,17 @@
 
   (testing "after nested flows complete"
     (testing "within nested flows "
-      (is (re-matches #"level 1 \(core_test.clj:\d+\)"
+      (is (re-matches #"level 1 \(core_test.clj:\d+\) -> \(state-flow\/current-description\) \(line \d+\)"
                       (first (state-flow/run (flow "level 1"
                                                (flow "level 2")
                                                (state-flow/current-description))))))
-      (is (re-matches #"level 1 \(core_test.clj:\d+\) -> level 2 \(core_test.clj:\d+\)"
+      (is (re-matches #"level 1 \(core_test.clj:\d+\) -> level 2 \(core_test.clj:\d+\) -> \(state-flow\/current-description\) \(line \d+\)"
                       (first (state-flow/run (flow "level 1"
                                                (flow "level 2"
                                                  (flow "level 3")
                                                  (state-flow/current-description)))))))
-      (is (re-matches #"level 1 \(core_test.clj:\d+\)"
+
+      (is (re-matches #"level 1 \(core_test.clj:\d+\) -> \(state-flow\/current-description\) \(line \d+\)"
                       (first (state-flow/run (flow "level 1"
                                                (flow "level 2"
                                                  (flow "level 3"))

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -110,29 +110,20 @@
     (is (= {}
            (second (state-flow/run! (flow "just return initial state"))))))
   (testing "run! throws exception"
-    (is (thrown-with-msg? Exception #"root \(line \d+\) -> child2 \(line \d+\)"
+    (is (thrown-with-msg? Exception #"root \(line \d+\) -> \`\(flow \"child\.\.\.\)\` \(line \d+\) -> child2 \(line \d+\)"
                           (test-helpers/run-flow bogus-flow {:value 0})))))
 
 (deftest as-step-fn
   (let [add-two-fn (state-flow/as-step-fn (state/modify #(+ 2 %)))]
     (is (= 3 (add-two-fn 1)))))
 
-(defn consecutive?
-  "Returns true iff ns (minimum of 2) all increase by 1"
-  [& ns]
-  (and (>= (count ns) 2)
-       (let [a (first ns)
-             z (inc (last ns))]
-         (and (< a z)
-              (= (range a z) ns)))))
-
 (deftest current-description
   (testing "top level flow"
-    (is (re-matches #"level 1 \(line \d+\)"
+    (is (re-matches #"level 1 \(line \d+\) -> \`\(state-flow\/\.\.\.\)\` \(line \d+\)"
                     (first (state-flow/run (flow "level 1" (state-flow/current-description)))))))
 
   (testing "nested flows"
-    (is (re-matches #"level 1 \(line \d+\) -> level 2 \(line \d+\)"
+    (is (re-matches #"level 1 \(line \d+\) -> \`\(flow \"level\.\.\.\)\` \(line \d+\) -> level 2 \(line \d+\) -> \`\(state-flow\/\.\.\.\)\` \(line \d+\)"
                     (first (state-flow/run (flow "level 1"
                                              (flow "level 2"
                                                (state-flow/current-description)))))))
@@ -145,19 +136,27 @@
                                    (flow "level 2"
                                      (flow "level 3"
                                        (state-flow/current-description)))))]
-      (is (re-matches #"level 1 \(line \d+\) -> level 2 \(line \d+\) -> level 3 \(line \d+\)" desc))
+      (is (re-matches #"level 1 \(line \d+\) -> \`\(flow \"level\.\.\.\)\` \(line \d+\) -> level 2 \(line \d+\) -> \`\(flow \"level\.\.\.\)\` \(line \d+\) -> level 3 \(line \d+\) -> \`\(state-flow\/\.\.\.\)\` \(line \d+\)"
+                      desc))
       (testing "line numbers are correct"
         (let [[level-1-line
+               level-1-call-line
                level-2-line
-               level-3-line]
+               level-2-call-line
+               level-3-line
+               level-3-call-line]
               (->> desc
-                   (re-find #"level 1 \(line (\d+)\) -> level 2 \(line (\d+)\) -> level 3 \(line (\d+)\)")
+                   (re-find #"level 1 \(line (\d+)\) -> \`\(flow \"level\.\.\.\)\` \(line (\d+)\) -> level 2 \(line (\d+)\) -> \`\(flow \"level\.\.\.\)\` \(line (\d+)\) -> level 3 \(line (\d+)\) -> \`\(state-flow\/\.\.\.\)\` \(line (\d+)\)")
                    (drop 1)
+                   nu/tap
                    (map #(Integer/parseInt %)))]
-          (is (consecutive? line-number-before-flow-invocation
-                            level-1-line
-                            level-2-line
-                            level-3-line))))))
+          (is (<= line-number-before-flow-invocation
+                  level-1-line
+                  level-1-call-line
+                  level-2-line
+                  level-2-call-line
+                  level-3-line
+                  level-3-call-line))))))
 
   (testing "composition"
     (let [line-number-before-flow-invocation (this-line-number)
@@ -165,33 +164,34 @@
           level-2  (flow "level 2" level-3)
           level-1  (flow "level 1" level-2)
           [desc _] (state-flow/run level-1)]
-      (is (re-matches #"level 1 \(line \d+\) -> level 2 \(line \d+\) -> level 3 \(line \d+\)"
+      (is (re-matches #"level 1 \(line \d+\) -> `level-2` -> level 2 \(line \d+\) -> `level-3` -> level 3 \(line \d+\) -> \`\(state-flow\/\.\.\.\)\` \(line \d+\)"
                       desc))
       (testing "line numbers are correct, even when composed"
         (let [[level-1-line
                level-2-line
-               level-3-line]
+               level-3-line
+               level-3-call-line]
               (->> desc
-                   (re-find #"level 1 \(line (\d+)\) -> level 2 \(line (\d+)\) -> level 3 \(line (\d+)\)")
+                   (re-find #"level 1 \(line (\d+)\) -> `level-2` -> level 2 \(line (\d+)\) -> `level-3` -> level 3 \(line (\d+)\) -> \`\(state-flow\/\.\.\.\)\` \(line (\d+)\)")
                    (drop 1)
                    (map #(Integer/parseInt %)))]
-          (is (consecutive? line-number-before-flow-invocation
-                            level-3-line
-                            level-2-line
-                            level-1-line))))))
+          (is (<= line-number-before-flow-invocation
+                  level-3-line
+                  level-2-line
+                  level-1-line))))))
 
   (testing "after nested flows complete"
     (testing "within nested flows "
-      (is (re-matches #"level 1 \(line \d+\)"
+      (is (re-matches #"level 1 \(line \d+\) -> \`\(state-flow\/\.\.\.\)\` \(line \d+\)"
              (first (state-flow/run (flow "level 1"
                                       (flow "level 2")
                                       (state-flow/current-description))))))
-      (is (re-matches #"level 1 \(line \d+\) -> level 2 \(line \d+\)"
+      (is (re-matches #"level 1 \(line \d+\) -> \`\(flow \"level\.\.\.\)\` \(line \d+\) -> level 2 \(line \d+\) -> \`\(state-flow\/\.\.\.\)\` \(line \d+\)"
              (first (state-flow/run (flow "level 1"
                                       (flow "level 2"
                                         (flow "level 3")
                                         (state-flow/current-description)))))))
-      (is (re-matches #"level 1 \(line \d+\)"
+      (is (re-matches #"level 1 \(line \d+\) -> \`\(state-flow\/\.\.\.\)\` \(line \d+\)"
              (first (state-flow/run (flow "level 1"
                                       (flow "level 2"
                                         (flow "level 3"))

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -159,15 +159,6 @@
   (let [add-two-fn (state-flow/as-step-fn (state/modify #(+ 2 %)))]
     (is (= 3 (add-two-fn 1)))))
 
-(defn consecutive?
-  "Returns true iff ns (minimum of 2) all increase by 1"
-  [& ns]
-  (and (>= (count ns) 2)
-       (let [a (first ns)
-             z (inc (last ns))]
-         (and (< a z)
-              (= (range a z) ns)))))
-
 (deftest current-description
   (testing "top level flow"
     (is (re-matches #"level 1 \(core_test.clj:\d+\)"
@@ -196,10 +187,10 @@
                    (re-find #"level 1 \(core_test.clj:(\d+)\) -> level 2 \(core_test.clj:(\d+)\) -> level 3 \(core_test.clj:(\d+)\)")
                    (drop 1)
                    (map #(Integer/parseInt %)))]
-          (is (consecutive? line-number-before-flow-invocation
-                            level-1-line
-                            level-2-line
-                            level-3-line))))))
+          (is (<= line-number-before-flow-invocation
+                  level-1-line
+                  level-2-line
+                  level-3-line))))))
 
   (testing "composition"
     (let [line-number-before-flow-invocation (this-line-number)
@@ -217,10 +208,10 @@
                    (re-find #"level 1 \(core_test.clj:(\d+)\) -> level 2 \(core_test.clj:(\d+)\) -> level 3 \(core_test.clj:(\d+)\)")
                    (drop 1)
                    (map #(Integer/parseInt %)))]
-          (is (consecutive? line-number-before-flow-invocation
-                            level-3-line
-                            level-2-line
-                            level-1-line))))))
+          (is (<= line-number-before-flow-invocation
+                  level-3-line
+                  level-2-line
+                  level-1-line))))))
 
   (testing "after nested flows complete"
     (testing "within nested flows "

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -230,7 +230,12 @@
                       (first (state-flow/run (flow "level 1"
                                                (flow "level 2"
                                                  (flow "level 3"))
-                                               (state-flow/current-description)))))))))
+                                               (state-flow/current-description))))))))
+  (testing "description in presence of exceptions"
+    (is (re-matches #"will boom \(core_test.clj:\d+\) -> root \(core_test.clj:\d+\) -> child2 \(core_test.clj:\d+\) -> bogus"
+                    (-> (state-flow/run (flow "will boom" bogus-flow) {:value 2})
+                        second
+                        (#'state-flow/state->current-description))))))
 
 (deftest top-level-description
   (let [tld (fn [flow] (->> (state-flow/run flow)


### PR DESCRIPTION
An attempt to help address https://github.com/nubank/state-flow/issues/74

Given a flow that raises an exception, like:
```clojure
(ns state-flow.scratch
  (:require [state-flow.core :as state-flow]
            [state-flow.cljtest :refer [match?]]
            [state-flow.state :as state]))

(defn inc-a [s]
  (update s :a inc))

(defn change-state-buggy []
  (state/modify inc-a))

(state-flow/run!
  (state-flow/flow "buggy flow"
                   (change-state-buggy)
                   (match? "never run" 1 2)))
```

the result used to be like the following, which doesn't help pinpoint that `(change-state-buggy)` is the offending step:

```
                state-flow.state/reify/fn       state.clj:   63
                 state-flow.scratch/inc-a     scratch.clj:    7
                      clojure.core/update        core.clj: 6196
                         clojure.core/inc        core.clj:  927
                                      ...
java.lang.NullPointerException:

Syntax error (ExceptionInfo) compiling at (state_flow/scratch.clj:12:1).
Flow "buggy flow (scratch.clj:13)" failed with exception
```

With the changes in this PR:

```
                state-flow.state/reify/fn       state.clj:   63
                 state-flow.scratch/inc-a     scratch.clj:    7
                      clojure.core/update        core.clj: 6196
                         clojure.core/inc        core.clj:  927
                                      ...
java.lang.NullPointerException:

Syntax error (ExceptionInfo) compiling at (state_flow/scratch.clj:12:1).
Flow "buggy flow (scratch.clj:13) -> (change-state-buggy) (line 14)" failed with exception
```

**Note:**

we don't have line metadata info for variable references, so

```clojure
(state-flow/run!
  (state-flow/flow "buggy flow"
                   change-state-buggy))
```

results in 
```

Syntax error (ExceptionInfo) compiling at (state_flow/scratch.clj:12:1).
Flow "buggy flow (scratch.clj:13) -> change-state-buggy" failed with exception
```
