### PR TITLE
probe refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.2.0]
+
+- Remove delay from the first try of `probe`
+- Refactor probe and change return value to include the probed value and check result of each try
+
 ## [2.1.5]
 
 - Make `state-flow.state/return` constructable/def'able outside monadic context.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "2.1.5"
+(defproject nubank/state-flow "2.2.0"
   :description "Postman-like integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}

--- a/src/state_flow/cljtest.clj
+++ b/src/state_flow/cljtest.clj
@@ -12,7 +12,7 @@
   ([state matcher]
    (match-probe state matcher {}))
   ([state matcher params]
-   (m/fmap second
+   (m/fmap (comp :value last)
            (probe/probe state
                         #(matcher-combinators/match? (matcher-combinators/match matcher %))
                         params))))

--- a/src/state_flow/midje.clj
+++ b/src/state_flow/midje.clj
@@ -16,9 +16,9 @@
   returns a State that runs left up to times-to-retry times every sleep-time ms until left-value equals right value."
   [desc state right-value metadata]
   `(ctx/with-context (ctx/infer ~state)
-     (m/mlet [[_# result#] (probe/probe ~state #(extended-= % ~right-value))]
-       (do (add-desc-and-meta (fact result# => ~right-value) ~desc ~metadata)
-           (m/return result#)))))
+     (m/mlet [result# (probe/probe ~state #(extended-= % ~right-value))]
+       (do (add-desc-and-meta (fact (:value (last result#)) => ~right-value) ~desc ~metadata)
+           (m/return (:value (last result#)))))))
 
 (defmacro verify
   "If left-value is a state, do fact probing. Otherwise, regular fact checking.

--- a/src/state_flow/probe.clj
+++ b/src/state_flow/probe.clj
@@ -39,7 +39,7 @@
 (defn ^:private probe*
   "evaluates state repeatedly with check-fn until check-fn succeeds or we try too many times"
   ([flow check-fn]
-   (probe* flow check-fn {:sleep-time default-sleep-time :times-to-try default-times-to-try}))
+   (probe* flow check-fn {}))
   ([flow check-fn {:keys [sleep-time times-to-try]
                    :or   {sleep-time   default-sleep-time
                           times-to-try default-times-to-try}}]

--- a/src/state_flow/probe.clj
+++ b/src/state_flow/probe.clj
@@ -11,38 +11,38 @@
 
 (defn ^:private check
   "Applies check-fn to the return value of a step, returns the check result and the original value in a map"
-  [flow check-fn]
-  (m/mlet [value flow]
+  [step check-fn]
+  (m/mlet [value step]
     (state/return {:check-result (check-fn value)
                    :value        value})))
 
 (defn ^:private with-delay
   "Adds a delay before the step is run"
-  [flow delay]
-  (m/>> (state/wrap-fn #(Thread/sleep delay)) flow))
+  [step delay]
+  (m/>> (state/wrap-fn #(Thread/sleep delay)) step))
 
 (defn ^:private sequence-while*
-  "Like cats.core/sequence but with short circuiting when pred is satisfied by the return value of a flow"
-  [pred acc flows]
-  (if (empty? flows)
+  "Like cats.core/sequence but with short circuiting when pred is satisfied by the return value of a step"
+  [pred acc steps]
+  (if (empty? steps)
     acc
-    (m/mlet [result (first flows)
+    (m/mlet [result (first steps)
              results acc]
       (if (pred result)
         (state/return (conj results result))
-        (sequence-while* pred (state/return (conj results result)) (rest flows))))))
+        (sequence-while* pred (state/return (conj results result)) (rest steps))))))
 
 (defn ^:private sequence-while
-  [pred flows]
-  (sequence-while* pred (state/return []) flows))
+  [pred steps]
+  (sequence-while* pred (state/return []) steps))
 
 (defn probe
   "Internal use only. Evaluates step repeatedly with check-fn until check-fn succeeds or we try too many times"
-  ([flow check-fn]
-   (probe flow check-fn {}))
-  ([flow check-fn {:keys [sleep-time times-to-try]
+  ([step check-fn]
+   (probe step check-fn {}))
+  ([step check-fn {:keys [sleep-time times-to-try]
                    :or   {sleep-time   default-sleep-time
                           times-to-try default-times-to-try}}]
    (sequence-while :check-result
-                   (cons (check flow check-fn)
-                         (repeat (dec times-to-try) (with-delay (check flow check-fn) sleep-time))))))
+                   (cons (check step check-fn)
+                         (repeat (dec times-to-try) (with-delay (check step check-fn) sleep-time))))))

--- a/src/state_flow/probe.clj
+++ b/src/state_flow/probe.clj
@@ -9,23 +9,52 @@
 (def default-sleep-time 200)
 (def default-times-to-try 5)
 
-(defn ^:private retry
-  "Tries at most n times, returns a vector with true and first element that succeeded
-  or false and result of the first try"
-  [times pred? lazy-seq]
-  (let [remaining (drop-while (complement pred?) (take times lazy-seq))]
-    (if (empty? remaining)
-      [false (first lazy-seq)]
-      [true  (first remaining)])))
+(defn ^:private check
+  "Applies check-fn to return value of a flow, returns the check result and the original value in a map"
+  [flow check-fn]
+  (m/mlet [value flow]
+    (state/return {:check-result (check-fn value)
+                   :value        value})))
+
+(defn ^:private with-delay
+  "Adds a delay when the flow is run"
+  [flow delay]
+  (m/>> (state/wrap-fn #(Thread/sleep delay)) flow))
+
+(defn ^:private sequence-while*
+  "Like cats.core/sequence but with short circuiting when pred is satisfied by the return value of a flow"
+  [pred acc flows]
+  (if (empty? flows)
+    acc
+    (m/mlet [result (first flows)
+             results acc]
+      (if (pred result)
+        (state/return (conj results result))
+        (sequence-while* pred (state/return (conj results result)) (rest flows))))))
+
+(defn ^:private sequence-while
+  [pred flows]
+  (sequence-while* pred (state/return []) flows))
+
+(defn ^:private probe*
+  "evaluates state repeatedly with check-fn until check-fn succeeds or we try too many times"
+  ([flow check-fn]
+   (probe* flow check-fn {:sleep-time default-sleep-time :times-to-try default-times-to-try}))
+  ([flow check-fn {:keys [sleep-time times-to-try]
+                   :or   {sleep-time   default-sleep-time
+                          times-to-try default-times-to-try}}]
+   (sequence-while :check-result (repeat times-to-try (with-delay (check flow check-fn) sleep-time)))))
+
+(defn ^:private probe-return
+  [{:keys [check-result value]}]
+  [(boolean check-result) value])
 
 (defn probe
   "evaluates state repeatedly with check-fn until check-fn succeeds or we try too many times"
   ([state check-fn]
    (probe state check-fn {:sleep-time default-sleep-time :times-to-try default-times-to-try}))
-  ([state check-fn {:keys [sleep-time times-to-try]
-                    :or   {sleep-time   default-sleep-time
-                           times-to-try default-times-to-try}}]
-   (m/mlet [world (state/get)
-            :let [runs   (repeatedly #(do (Thread/sleep sleep-time) (state/eval state world)))
-                  result (retry times-to-try check-fn runs)]]
-     (state/return result))))
+  ([flow check-fn {:keys [sleep-time times-to-try]
+                   :or   {sleep-time   default-sleep-time
+                          times-to-try default-times-to-try}}]
+   (m/fmap (comp probe-return last) (probe* flow check-fn {:sleep-time sleep-time :times-to-try times-to-try}))))
+

--- a/src/state_flow/probe.clj
+++ b/src/state_flow/probe.clj
@@ -52,7 +52,7 @@
 (defn probe
   "evaluates state repeatedly with check-fn until check-fn succeeds or we try too many times"
   ([state check-fn]
-   (probe state check-fn {:sleep-time default-sleep-time :times-to-try default-times-to-try}))
+   (probe state check-fn {}))
   ([flow check-fn {:keys [sleep-time times-to-try]
                    :or   {sleep-time   default-sleep-time
                           times-to-try default-times-to-try}}]

--- a/test/state_flow/cljtest_test.clj
+++ b/test/state_flow/cljtest_test.clj
@@ -40,7 +40,7 @@
              (flow "flow"
                (test-helpers/delayed-add-two 100)
                (cljtest/match? "2" get-value-state 2 {:times-to-try 2
-                                                      :sleep-time 75}))
+                                                      :sleep-time 110}))
              {:value (atom 0)})]
         (testing "returns actual (derived from state)"
           (is (= 2 flow-ret))))))

--- a/test/state_flow/probe_test.clj
+++ b/test/state_flow/probe_test.clj
@@ -2,7 +2,8 @@
   (:require [clojure.test :as t :refer [deftest testing is]]
             [state-flow.core :as state-flow]
             [state-flow.probe :as probe]
-            [state-flow.test-helpers :as test-helpers]))
+            [state-flow.test-helpers :as test-helpers]
+            [state-flow.state :as state]))
 
 (deftest test-probe
   (let [[flow-return flow-state] (state-flow/run (probe/probe test-helpers/add-two #(= % 3)) {:value 1})]

--- a/test/state_flow/probe_test.clj
+++ b/test/state_flow/probe_test.clj
@@ -7,23 +7,23 @@
 (deftest test-probe
   (let [[flow-return flow-state] (state-flow/run (probe/probe test-helpers/add-two #(= % 3)) {:value 1})]
     (testing "returns a tuple of [check-fn-result state-fn-return]"
-      (is (= [true 3] flow-return)))
+      (is (= [{:check-result true :value 3}] flow-return)))
     (testing "doesn't change state if state-fn doesn't change state"
       (is (= {:value 1} flow-state))))
   (testing "with delay < timeout"
     (let [state {:value (atom 0)}]
       (is (= 0 (->> (state-flow/run (test-helpers/delayed-add-two 100) state) last :value deref)))
-      (is (= [true 2]
+      (is (= [{:value 0 :check-result false} {:value 2 :check-result true}]
              (first (state-flow/run (probe/probe test-helpers/get-value-state #(= 2 %)) state))))))
   (testing "with delay > timeout"
     (let [state {:value (atom 0)}]
       (is (= 0 (->> (state-flow/run (test-helpers/delayed-add-two 1500) state) last :value deref)))
-      (is (= [false 0]
+      (is (= (repeat 5 {:check-result false :value 0})
              (first (state-flow/run (probe/probe test-helpers/get-value-state #(= 2 %)) state))))))
   (testing "with modified sleep-time and times-to-try"
     (let [state {:value (atom 0)}]
-      (is (= 0 (->> (state-flow/run (test-helpers/delayed-add-two 1100) state) last :value deref)))
-      (is (= [true 2]
+      (is (= 0 (->> (state-flow/run (test-helpers/delayed-add-two 950) state) last :value deref)))
+      (is (= (conj (vec (repeat 4 {:check-result false :value 0})) {:check-result true :value 2})
              (first (state-flow/run (probe/probe test-helpers/get-value-state #(= 2 %)
                                                  {:sleep-time   250
                                                   :times-to-try 5})

--- a/test/state_flow/probe_test.clj
+++ b/test/state_flow/probe_test.clj
@@ -2,8 +2,7 @@
   (:require [clojure.test :as t :refer [deftest testing is]]
             [state-flow.core :as state-flow]
             [state-flow.probe :as probe]
-            [state-flow.test-helpers :as test-helpers]
-            [state-flow.state :as state]))
+            [state-flow.test-helpers :as test-helpers]))
 
 (deftest test-probe
   (let [[flow-return flow-state] (state-flow/run (probe/probe test-helpers/add-two #(= % 3)) {:value 1})]


### PR DESCRIPTION
Refactoring of probe to allow users to gather more information from probe tries.

Tests are passing without change, so `probe` still has the same semantics, but also added `probe*` that returns a list of maps representing each try of `check-fn`.

This approach is (arguably) less ugly, more generic and also less efficient (because of non tail recursion) than the previous approach.

`sequence-while` could be moved to cats.core and made generic in order to work for any monad.

Needs polishing up and more tests, accepting feedback before going forward with this