### PR TITLE
Introduce new match? fn in a new namespace and deprecate old one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.2.2]
+
+- Introduce `state-flow.assertions.matcher-combinators/match?`
+  - deprecate `state-flow.cljtest/match?`
+  - add `state-flow.refactoring-tools.refactor-match/refactor-all` to help with
+    refactoring to the new version
+
 ## [2.2.1]
 - Use vectors in internal state data structure instead of cats pairs
 

--- a/README.md
+++ b/README.md
@@ -155,42 +155,73 @@ Or we could increment the value first and then return it doubled:
 We use the `defflow` and `match?` macros to build `clojure.test` tests
 out of flows.
 
-`defflow` defines a test (using `deftest`) that when
+`state-flow.cljtest.defflow` defines a test (using `deftest`) that when
 run, will execute the flow with the parameters that we set.
 
-`match?` produces a flow that will make a `clojure.test` assertion. It
+`state-flow.assertions.match?` produces a flow that will make an assertion, which
+will be reported via clojure.test when used within a `defflow`. It
 uses the
 [`nubank/matcher-combinators`](https://github.com/nubank/matcher-combinators/)
 library for the actual check and failure messages. `match?` asks for:
 
-* a string description
-* the actual value, or a step which will produce it
-  * if you supply a value, `match?` will wrap it in `(state/return <value>)`
 * the expected value, or a matcher-combinators matcher
   * if you supply a value, matcher-combintators will apply its defaults
+* the actual value, or a step which will produce it
+  * if you supply a value, `match?` will wrap it in `(state/return <value>)`
 
 Here are some very simple examples of tests defined using `defflow`:
 
 ```clojure
 (defflow my-flow
-  (match? "simple test" 1 1)
-  (match? "embeds" {:a 1 :b 2} {:a 1}))
+  (match? 1 1)
+  (match? {:a 1 :b 2} {:a 1}))
 ```
+
+Wrap them in `flow`s to get descriptions when the expected and actual
+values need some explanation:
+
+```clojure
+(deftest fruits-and-veggies
+  (flow "surprise! Tomatoes are fruits!"
+    (match? #{:tomato} (fruits #{:tomato :potato}))))
+```
+
 Or with custom parameters:
 
 ```clojure
 (defflow my-flow {:init aux.init! :runner (comp run! s/with-fn-validation)}
-  (match? "simple test" 1 1)
-  (match? "simple test 2" 2 2))
+  (match? 1 1)
+  (match? 2 2))
 ```
 
 ```clojure
 (defflow my-flow {:init (constantly {:value 1
                                      :map {:a 1 :b 2}})}
   [value (state/gets :value)]
-  (match? "value is correct" value 1)
-  (match? "embeds" (state/gets :map) {:b 2}))
+  (match? 1 value)
+  (flow "uses matcher-combinator embeds"
+    (match? {:b 2} (state/gets :map)))
 ```
+
+### NOTE: about upgrading to state-flow-2.2.2
+
+We introduced `state-flow.assertions.match?` in state-flow-2.2.2, and
+deprecated `state-flow.cljtest.match?` in that release. The signature
+for the old version was `(match? <description> <actual> <expected>)`.
+We removed the description because it was quite common for the description
+to add no context that wasn't already made clear by the expected and
+actual values.
+
+We also reversed the order of expected and actual in order to align
+with the `match?` function in the matcher-combinators library and with
+clojure.test's `(is (= expected actual))`.
+
+In order to ease refactoring, we also added a `refactor-match`
+function, which takes a path to a file and some configuration options
+about what you want the refactoring to do.
+
+See the `state-flow.refactoring-tools.refactor-match` ns for
+details.
 
 ## Midje Support
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "2.2.1"
+(defproject nubank/state-flow "2.2.2"
   :description "Postman-like integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}

--- a/project.clj
+++ b/project.clj
@@ -29,7 +29,8 @@
                    :dependencies [[ns-tracker "0.4.0"]
                                   [org.clojure/tools.namespace "0.3.1"]
                                   [midje "1.9.9"]
-                                  [org.clojure/java.classpath "0.3.0"]]}}
+                                  [org.clojure/java.classpath "0.3.0"]
+                                  [rewrite-clj "0.6.1"]]}}
 
   :aliases {"coverage" ["cloverage" "-s" "coverage"]
             "lint"     ["do" ["cljfmt" "check"] ["nsorg"]]

--- a/src/state_flow/assertions/matcher_combinators.clj
+++ b/src/state_flow/assertions/matcher_combinators.clj
@@ -5,15 +5,6 @@
             [state-flow.probe :as probe]
             [state-flow.state :as state]))
 
-(defn ^:private ensure-wrapped
-  "Internal use only.
-
-  Given a state-flow step, returns value as/is, else wraps value in a state-flow step."
-  [value]
-  (if (state/state? value)
-    value
-    (state/return value)))
-
 (defn ^:private match-probe
   "Internal use only.
 
@@ -57,8 +48,8 @@
       `(m/do-let
         [flow-desc# (core/current-description)
          actual#    (if (> (:times-to-try ~params*) 1)
-                      (#'match-probe (#'ensure-wrapped ~actual) ~expected ~params*)
-                      (#'ensure-wrapped ~actual))]
+                      (#'match-probe (state/ensure-step ~actual) ~expected ~params*)
+                      (state/ensure-step ~actual))]
         ;; TODO: (dchelimsky, 2020-02-11) we plan to decouple
         ;; assertions from reporting in a future release. Remove this
         ;; next line when that happens.

--- a/src/state_flow/assertions/matcher_combinators.clj
+++ b/src/state_flow/assertions/matcher_combinators.clj
@@ -1,0 +1,57 @@
+(ns state-flow.assertions.matcher-combinators
+  (:require [cats.core :as m]
+            [matcher-combinators.core :as matcher-combinators]
+            [state-flow.core :as core]
+            [state-flow.probe :as probe]
+            [state-flow.state :as state]))
+
+(defn ^:private ensure-wrapped
+  "Internal use only.
+
+  Given a state-flow step, returns value as/is, else wraps value in a state-flow step."
+  [value]
+  (if (state/state? value)
+    value
+    (state/return value)))
+
+(defn ^:private match-probe
+  "Internal use only.
+
+  Returns the right value returned by probe/probe."
+  [state matcher params]
+  (m/fmap second
+          (probe/probe state
+                       #(matcher-combinators/match? (matcher-combinators/match matcher %))
+                       params)))
+
+(defmacro match?
+  "Builds a state-flow assertion using matcher-combinators.
+
+  - expected can be a literal value or a matcher-combinators matcher
+  - actual can be a literal value, a primitive, or a flow
+  - params is an optional map supporting:
+    - :times-to-try optional, default 1
+    - :sleep-time   optional, default 200
+
+  Given (> :times-to-try 1), match? will use `state-flow-probe/probe` to
+  retry :times-to-try times with :sleep-time
+
+  See `state-flow.probe/probe` for more info"
+  ([expected actual]
+   `(match? ~expected ~actual {:times-to-try 1}))
+  ([expected actual {:keys [times-to-try]
+                     :or {times-to-try 1}
+                     :as params}]
+   (core/flow*
+    {:description "match?"
+     :caller-meta (meta &form)}
+    ;; Nesting m/do-let inside a call the function core/flow* is
+    ;; a bit ugly, but it supports getting the correct line number
+    ;; information from core/current-description.
+    `(m/do-let
+      [flow-desc# (core/current-description)
+       actual#    (if (> (:times-to-try ~params) 1)
+                    (#'match-probe (#'ensure-wrapped ~actual) ~expected ~params)
+                    (#'ensure-wrapped ~actual))]
+      (state/wrap-fn #(t/testing flow-desc# (t/is (~'match? ~expected actual#))))
+      (state/return actual#)))))

--- a/src/state_flow/assertions/matcher_combinators.clj
+++ b/src/state_flow/assertions/matcher_combinators.clj
@@ -28,7 +28,7 @@
   "Builds a state-flow assertion using matcher-combinators.
 
   - expected can be a literal value or a matcher-combinators matcher
-  - actual can be a literal value, a primitive, or a flow
+  - actual can be a literal value, a primitive step, or a flow
   - params is an optional map supporting:
     - :times-to-try optional, default 1
     - :sleep-time   optional, default 200

--- a/src/state_flow/assertions/matcher_combinators.clj
+++ b/src/state_flow/assertions/matcher_combinators.clj
@@ -35,21 +35,21 @@
    ;; deprecated cljtest/match? fn.  Undecided
    ;; whether we want to make it part of the API.
    ;; caller-meta is definitely not part of the API.
-   (let [params* (merge {:description "match?"
-                         :caller-meta (meta &form)
-                         :times-to-try 1}
+  (let [params* (merge {:description "match?"
+                        :caller-meta (meta &form)
+                        :times-to-try 1}
                        params)]
-     (core/flow*
-      {:description (:description params*)
-       :caller-meta (:caller-meta params*)}
+    (core/flow*
+     {:description (:description params*)
+      :caller-meta (:caller-meta params*)}
       ;; Nesting m/do-let inside a call the function core/flow* is
       ;; a bit ugly, but it supports getting the correct line number
       ;; information from core/current-description.
-      `(m/do-let
-        [flow-desc# (core/current-description)
-         actual#    (if (> (:times-to-try ~params*) 1)
-                      (#'match-probe (state/ensure-step ~actual) ~expected ~params*)
-                      (state/ensure-step ~actual))]
+     `(m/do-let
+       [flow-desc# (core/current-description)
+        actual#    (if (> (:times-to-try ~params*) 1)
+                     (#'match-probe (state/ensure-step ~actual) ~expected ~params*)
+                     (state/ensure-step ~actual))]
         ;; TODO: (dchelimsky, 2020-02-11) we plan to decouple
         ;; assertions from reporting in a future release. Remove this
         ;; next line when that happens.
@@ -60,5 +60,5 @@
         ;; exploring this macro in _this_ namespace, and try to invoke
         ;; it, you'll get a stack overflow because the compiler
         ;; interprets match? as this macro.
-        (state/wrap-fn #(~'clojure.test/testing flow-desc# (~'clojure.test/is (~'match? ~expected actual#))))
-        (state/return actual#)))))
+       (state/wrap-fn #(~'clojure.test/testing flow-desc# (~'clojure.test/is (~'match? ~expected actual#))))
+       (state/return actual#)))))

--- a/src/state_flow/cljtest.clj
+++ b/src/state_flow/cljtest.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :as t]
             [state-flow.core :as core]
             [state-flow.probe :as probe]
-            [state-flow.assertions.matcher-combinators :as amc]))
+            [state-flow.assertions.matcher-combinators]))
 
 (defmacro match?
   "DEPRECATED. Use state-flow.assertions.matcher-combinators/match? instead. "
@@ -12,7 +12,7 @@
                         :caller-meta  (meta &form)
                         :description  match-desc}
                        params)]
-    `(amc/match? ~expected ~actual ~params*)))
+    `(~'state-flow.assertions.matcher-combinators/match? ~expected ~actual ~params*)))
 
 (defmacro defflow
   {:arglists '([name & flows]

--- a/src/state_flow/cljtest.clj
+++ b/src/state_flow/cljtest.clj
@@ -4,7 +4,7 @@
             [state-flow.probe :as probe]
             [state-flow.assertions.matcher-combinators]))
 
-(defmacro match?
+(defmacro ^:deprecated match?
   "DEPRECATED. Use state-flow.assertions.matcher-combinators/match? instead. "
   [match-desc actual expected & [params]]
   (let [params* (merge {:times-to-try probe/default-times-to-try

--- a/src/state_flow/cljtest.clj
+++ b/src/state_flow/cljtest.clj
@@ -1,41 +1,18 @@
 (ns state-flow.cljtest
-  (:require [cats.core :as m]
-            [clojure.test :as t]
-            [matcher-combinators.core :as matcher-combinators]
-            [matcher-combinators.test]
+  (:require [clojure.test :as t]
             [state-flow.core :as core]
             [state-flow.probe :as probe]
-            [state-flow.state :as state]))
-
-(defn match-probe
-  "Returns the right value returned by probe/probe."
-  ([state matcher]
-   (match-probe state matcher {}))
-  ([state matcher params]
-   (m/fmap (comp :value last)
-           (probe/probe state
-                        #(matcher-combinators/match? (matcher-combinators/match matcher %))
-                        params))))
+            [state-flow.assertions.matcher-combinators :as amc]))
 
 (defmacro match?
-  "Builds a clojure.test assertion using matcher-combinators.
-
-  - actual can be a literal value, a primitive, or a flow
-  - expected can be a literal value or a matcher-combinators matcher"
+  "DEPRECATED. Use state-flow.assertions.matcher-combinators/match? instead. "
   [match-desc actual expected & [params]]
-  ;; Nesting m/do-let inside a call the function core/flow* is
-  ;; a bit ugly, but it supports getting the correct line number
-  ;; information from core/current-description.
-  (core/flow*
-   {:description match-desc
-    :caller-meta (meta &form)}
-   `(m/do-let
-     [flow-desc# (core/current-description)
-      actual#    (if (state/state? ~actual)
-                   (match-probe ~actual ~expected ~params)
-                   (state/return ~actual))]
-     (state/wrap-fn #(t/testing flow-desc# (t/is (~'match? ~expected actual#))))
-     (state/return actual#))))
+  (let [params* (merge {:times-to-try probe/default-times-to-try
+                        :sleep-time   probe/default-sleep-time
+                        :caller-meta  (meta &form)
+                        :description  match-desc}
+                       params)]
+    `(amc/match? ~expected ~actual ~params*)))
 
 (defmacro defflow
   {:arglists '([name & flows]

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -64,7 +64,7 @@
   For internal use. Subject to change."
   []
   (m/mlet [desc-list (state/gets description-stack)]
-          (m/return (format-description desc-list))))
+    (m/return (format-description desc-list))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Public API

--- a/src/state_flow/labs/cljtest.clj
+++ b/src/state_flow/labs/cljtest.clj
@@ -6,6 +6,6 @@
 (defmacro testing [desc & body]
   "state-flow's equivalent to clojure test's `testing`"
   `(core/flow ~desc
-              [full-desc# (core/current-description)]
-              (state/wrap-fn #(do ~(with-meta `(ctest/testing ~desc ~@body)
-                                     (meta &form))))))
+     [full-desc# (core/current-description)]
+     (state/wrap-fn #(do ~(with-meta `(ctest/testing ~desc ~@body)
+                            (meta &form))))))

--- a/src/state_flow/refactoring_tools/refactor_match.clj
+++ b/src/state_flow/refactoring_tools/refactor_match.clj
@@ -1,0 +1,117 @@
+(ns state-flow.refactoring-tools.refactor-match
+  "This ns contains tools to refactor from match? in the cljtest
+  ns to the new version in the assertions.matcher-combinators ns."
+  (:require [clojure.java.io :as io]
+            [rewrite-clj.zip :as z]))
+
+(defn refactor-match-expr
+  "
+  If there is an exception, printlns the expression so you can
+  find and handle it manually."
+  [{:keys [wrap-in-testing
+           sym-after]}
+   zloc]
+  (try
+    (let [match-sym  (-> zloc z/down)
+          desc       (-> match-sym z/right)
+          actual     (-> desc z/right)
+          expected   (-> actual z/right)
+          refactored (z/edit-> zloc
+                               z/down
+                               (z/replace sym-after)
+                               z/right
+                               z/remove
+                               z/right
+                               (z/replace (z/node expected))
+                               z/right
+                               (z/replace (z/node actual)))]
+      (if wrap-in-testing
+        (z/edit-> zloc
+                  (z/replace
+                   (-> (z/of-string "(testing)")
+                       (z/append-child (z/node desc))
+                       (z/append-child (z/node refactored))
+                       (z/node))))
+        refactored))
+    (catch Exception e
+      (println "Error processing " (z/string zloc))
+      zloc)))
+
+(defn match-expr? [match-sym node]
+  (when (= :list (z/tag node))
+    (when-let [op (z/down node)]
+      (= match-sym (z/value op)))))
+
+(defn ^:private refactor-all* [{:keys [sym-before] :as opts} data]
+  (loop [data data]
+    (let [updated (try
+                    (z/prewalk data
+                               (partial match-expr? sym-before)
+                               (partial refactor-match-expr opts))
+                    (catch Exception _ data))]
+      (if (z/rightmost? updated)
+        updated
+        (recur (z/right updated))))))
+
+(defn refactor-all
+  "Given a map with :path to a file or a string :str, returns
+  a string with all of the match? expressions refactored as follows:
+
+  Given a match? expression e.g.
+
+    (match? <description> <actual> <expected>)
+    ;; or
+    (match? <description> <actual> <expected> <params>)
+
+  Returns an expect expression e.g.
+
+    (match? <expected> <actual>)
+    ;; or
+    (match? <expected> <actual> <params>)
+
+  With :wrap-in-testing set to true, returns e.g.
+
+    (testing <description> (match? <expected> <actual>))
+    ;; or
+    (testing <description> (match? <expected> <actual> <params>))
+
+  Supported keys:
+  - :str             this or path are required   - string source for the refactoring
+  - :path            this or str are required    - path to source for refactoring
+  - :rewrite         optional (default false)    - rewrites refactored code to the same path
+  - :sym-before      optional (default `match?`) - symbol to look for for match? expressions
+                       - use this key if you've got a qualified symbol
+  - :sym-after       optional (default `match?`) - symbol to replace :sym-before
+  - :wrap-in-testing optional (default false)    - set to true to wrap in testing
+
+  This is intended to help you in refactoring to the new match? function, however
+  there are some things you'll need to do on your own:
+
+  - before
+    - ensure that the the `match?` expressions you wish to refactor use the same
+      symbol (simple or qualified) before refactoring
+  - after
+    - reformat for whitespace (manually or w/ cljfmt)
+  - before or after
+    - update the ns declaration to include state-flow.assertions.matcher-combinators
+      - if :sym-after is simple i.e. just `match?`, then `:refer [match?]`
+      - if :sym-after is qualified, then use `:as <alias>`"
+  [{:keys [path str
+           rewrite
+           wrap-in-testing
+           sym-before
+           sym-after]
+    :as opts}]
+  (let [z-before (or (and path (z/of-file path))
+                     (and str (z/of-string str)))
+        z-after  (z/root-string (refactor-all* opts z-before))]
+    (if (and path rewrite)
+      (spit (io/file path) z-after)
+      z-after)))
+
+(comment
+  (refactor-all {:path "test/state_flow/cljtest_test.clj"
+                 :sym-before 'cljtest/match?
+                 :sym-after 'assertions.matcher-combinators/match?
+                 :wrap-in-testing true
+                 :rewrite true}))

--- a/src/state_flow/refactoring_tools/refactor_match.clj
+++ b/src/state_flow/refactoring_tools/refactor_match.clj
@@ -5,10 +5,9 @@
             [rewrite-clj.zip :as z]))
 
 (defn refactor-match-expr
-  "
-  If there is an exception, printlns the expression so you can
+  "If there is an exception, printlns the expression so you can
   find and handle it manually."
-  [{:keys [wrap-in-testing
+  [{:keys [wrap-in-flow
            sym-after]}
    zloc]
   (try
@@ -25,10 +24,10 @@
                                (z/replace (z/node expected))
                                z/right
                                (z/replace (z/node actual)))]
-      (if wrap-in-testing
+      (if wrap-in-flow
         (z/edit-> zloc
                   (z/replace
-                   (-> (z/of-string "(testing)")
+                   (-> (z/of-string "(flow)")
                        (z/append-child (z/node desc))
                        (z/append-child (z/node refactored))
                        (z/node))))
@@ -69,11 +68,11 @@
     ;; or
     (match? <expected> <actual> <params>)
 
-  With :wrap-in-testing set to true, returns e.g.
+  With :wrap-in-flow set to true, returns e.g.
 
-    (testing <description> (match? <expected> <actual>))
+    (flow <description> (match? <expected> <actual>))
     ;; or
-    (testing <description> (match? <expected> <actual> <params>))
+    (flow <description> (match? <expected> <actual> <params>))
 
   Supported keys:
   - :str             this or path are required   - string source for the refactoring
@@ -82,7 +81,8 @@
   - :sym-before      optional (default `match?`) - symbol to look for for match? expressions
                        - use this key if you've got a qualified symbol
   - :sym-after       optional (default `match?`) - symbol to replace :sym-before
-  - :wrap-in-testing optional (default false)    - set to true to wrap in testing
+  - :wrap-in-flow    optional (default false)    - set to true to wrap in a flow with the description
+                                                   from the source match? expression
 
   This is intended to help you in refactoring to the new match? function, however
   there are some things you'll need to do on your own:
@@ -98,7 +98,7 @@
       - if :sym-after is qualified, then use `:as <alias>`"
   [{:keys [path str
            rewrite
-           wrap-in-testing
+           wrap-in-flow
            sym-before
            sym-after]
     :as opts}]
@@ -113,5 +113,5 @@
   (refactor-all {:path "test/state_flow/cljtest_test.clj"
                  :sym-before 'cljtest/match?
                  :sym-after 'assertions.matcher-combinators/match?
-                 :wrap-in-testing true
+                 :wrap-in-flow true
                  :rewrite true}))

--- a/src/state_flow/state.clj
+++ b/src/state_flow/state.clj
@@ -99,3 +99,12 @@
 (def run state/run)
 (def eval state/eval)
 (def exec state/exec)
+
+(defn ensure-step
+  "Internal use only.
+
+  Given a state-flow step, returns value as/is, else wraps value in a state-flow step."
+  [value]
+  (if (state? value)
+    value
+    (return value)))

--- a/test/state_flow/cljtest_test.clj
+++ b/test/state_flow/cljtest_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :as t :refer [deftest testing is]]
             [matcher-combinators.test :refer [match?]]
             [matcher-combinators.matchers :as matchers]
+            [state-flow.assertions.matcher-combinators :as amc]
             [state-flow.test-helpers :as test-helpers :refer [this-line-number]]
             [state-flow.cljtest :as cljtest :refer [defflow]]
             [state-flow.core :as state-flow :refer [flow]]
@@ -12,23 +13,22 @@
 (deftest test-match?
   (testing "passing cases"
     (testing "with literals for expected and actual"
-      (let [[ret state] (state-flow/run (cljtest/match? "DESC" 3 3) {:initial :state})]
+      (let [[ret state] (state-flow/run (amc/match? 3 3) {:initial :state})]
         (testing "returns actual (literal)"
           (is (= 3 ret)))
         (testing "doesn't change state"
           (is (= {:initial :state} state)))))
 
     (testing "with state monad for actual"
-      (let [[ret state] (state-flow/run (cljtest/match? "DESC" test-helpers/add-two 3) {:value 1})]
+      (let [[ret state] (state-flow/run (amc/match? 3 test-helpers/add-two) {:value 1})]
         (testing "returns actual (derived from state)"
           (is (= 3 ret)))
         (testing "doesn't change state"
           (is (= {:value 1} state)))))
 
     (testing "with explicit matcher for expected"
-      (let [[ret state] (state-flow/run (cljtest/match? "DESC"
-                                                        test-helpers/add-two
-                                                        (matchers/equals 3)) {:value 1})]
+      (let [[ret state] (state-flow/run (amc/match? (matchers/equals 3)
+                                                    test-helpers/add-two) {:value 1})]
         (testing "returns actual (derived from state)"
           (is (= 3 ret)))
         (testing "doesn't change state"
@@ -39,8 +39,8 @@
             (test-helpers/run-flow
              (flow "flow"
                (test-helpers/delayed-add-two 100)
-               (cljtest/match? "2" get-value-state 2 {:times-to-try 2
-                                                      :sleep-time 110}))
+               (amc/match? 2 get-value-state {:times-to-try 2
+                                              :sleep-time 110}))
              {:value (atom 0)})]
         (testing "returns actual (derived from state)"
           (is (= 2 flow-ret))))))
@@ -50,10 +50,9 @@
       (let [three-lines-before-call-to-match (this-line-number)
             {:keys [flow-ret flow-state report-data]}
             (test-helpers/run-flow
-             (cljtest/match? "contains with monadic left value"
-                             (state/gets :value)
-                             (matchers/equals {:n 1})
-                             {:times-to-try 2})
+             (amc/match? (matchers/equals {:n 1})
+                         (state/gets :value)
+                         {:times-to-try 2})
              {:value {:n 2}})]
         (testing "returns actual"
           (is (= {:n 2} flow-ret)))
@@ -69,8 +68,8 @@
             (test-helpers/run-flow
              (flow "flow"
                (test-helpers/delayed-add-two 200)
-               (cljtest/match? "2" get-value-state 2 {:times-to-try 2
-                                                      :sleep-time 75}))
+               (amc/match? 2 get-value-state {:times-to-try 2
+                                              :sleep-time 75}))
              {:value (atom 0)})]
         (testing "returns actual (derived from state)"
           (is (= 0 flow-ret)))
@@ -83,15 +82,15 @@
 ;; in the deftest below causes test failures. I think it has to do with calling macroexpand
 ;; within a macro body.
 (def flow-with-defaults
-  (macroexpand-1 '(defflow my-flow (cljtest/match? "equals" 1 1))))
+  (macroexpand-1 '(defflow my-flow (amc/match? 1 1))))
 (def flow-with-optional-args
-  (macroexpand-1 '(defflow my-flow {:init (constantly {:value 1})} (cljtest/match? "equals" 1 1))))
+  (macroexpand-1 '(defflow my-flow {:init (constantly {:value 1})} (amc/match? 1 1))))
 (def flow-with-binding-and-match
   (macroexpand-1 '(defflow my-flow {:init (constantly {:value 1
                                                        :map {:a 1 :b 2}})}
                     [value (state/gets :value)]
-                    (cljtest/match? value 1)
-                    (cljtest/match? (state/gets :map) {:b 2}))))
+                    (amc/match? value 1)
+                    (amc/match? (state/gets :map) {:b 2}))))
 
 (deftest test-defflow
   (testing "defines flow with default parameters"
@@ -99,7 +98,7 @@
               my-flow
               (state-flow.core/run*
                 {}
-                (state-flow.core/flow "my-flow" (cljtest/match? "equals" 1 1))))
+                (state-flow.core/flow "my-flow" (amc/match? 1 1))))
            flow-with-defaults)))
 
   (testing "defines flow with optional parameters"
@@ -107,7 +106,7 @@
               my-flow
               (state-flow.core/run*
                 {:init (constantly {:value 1})}
-                (state-flow.core/flow "my-flow" (cljtest/match? "equals" 1 1))))
+                (state-flow.core/flow "my-flow" (amc/match? 1 1))))
            flow-with-optional-args)))
 
   (testing "defines flow with binding and flow inside match?"
@@ -118,15 +117,16 @@
                 (state-flow.core/flow
                   "my-flow"
                   [value (state/gets :value)]
-                  (cljtest/match? value 1)
-                  (cljtest/match? (state/gets :map) {:b 2}))))
+                  (amc/match? value 1)
+                  (amc/match? (state/gets :map) {:b 2}))))
            flow-with-binding-and-match))))
+
 
 (defflow my-flow {:init (constantly {:value 1
                                      :map   {:a 1 :b 2}})}
   [value (state/gets :value)]
-  (cljtest/match? "1" value 1)
-  (cljtest/match? "b is 2" (state/gets :map) {:b 2}))
+  (amc/match? 1 value)
+  (amc/match? {:b 2} (state/gets :map)))
 
 (deftest run-a-flow
   (is (match? {:value 1

--- a/test/state_flow/cljtest_test.clj
+++ b/test/state_flow/cljtest_test.clj
@@ -2,7 +2,6 @@
   (:require [clojure.test :as t :refer [deftest testing is]]
             [matcher-combinators.test :refer [match?]]
             [matcher-combinators.matchers :as matchers]
-            [state-flow.assertions.matcher-combinators :as assertions.matcher-combinators]
             [state-flow.test-helpers :as test-helpers :refer [this-line-number]]
             [state-flow.cljtest :as cljtest :refer [defflow]]
             [state-flow.core :as state-flow :refer [flow]]
@@ -13,22 +12,23 @@
 (deftest test-match?
   (testing "passing cases"
     (testing "with literals for expected and actual"
-      (let [[ret state] (state-flow/run (assertions.matcher-combinators/match? 3 3) {:initial :state})]
+      (let [[ret state] (state-flow/run (cljtest/match? "DESC" 3 3) {:initial :state})]
         (testing "returns actual (literal)"
           (is (= 3 ret)))
         (testing "doesn't change state"
           (is (= {:initial :state} state)))))
 
     (testing "with state monad for actual"
-      (let [[ret state] (state-flow/run (assertions.matcher-combinators/match? 3 test-helpers/add-two) {:value 1})]
+      (let [[ret state] (state-flow/run (cljtest/match? "DESC" test-helpers/add-two 3) {:value 1})]
         (testing "returns actual (derived from state)"
           (is (= 3 ret)))
         (testing "doesn't change state"
           (is (= {:value 1} state)))))
 
     (testing "with explicit matcher for expected"
-      (let [[ret state] (state-flow/run (assertions.matcher-combinators/match? (matchers/equals 3)
-                                                                               test-helpers/add-two) {:value 1})]
+      (let [[ret state] (state-flow/run (cljtest/match? "DESC"
+                                                        test-helpers/add-two
+                                                        (matchers/equals 3)) {:value 1})]
         (testing "returns actual (derived from state)"
           (is (= 3 ret)))
         (testing "doesn't change state"
@@ -39,8 +39,8 @@
             (test-helpers/run-flow
              (flow "flow"
                (test-helpers/delayed-add-two 100)
-               (assertions.matcher-combinators/match? 2 get-value-state {:times-to-try 2
-                                                                         :sleep-time 110}))
+               (cljtest/match? "2" get-value-state 2 {:times-to-try 2
+                                                      :sleep-time 110}))
              {:value (atom 0)})]
         (testing "returns actual (derived from state)"
           (is (= 2 flow-ret))))))
@@ -50,9 +50,10 @@
       (let [three-lines-before-call-to-match (this-line-number)
             {:keys [flow-ret flow-state report-data]}
             (test-helpers/run-flow
-             (assertions.matcher-combinators/match? (matchers/equals {:n 1})
-                                                    (state/gets :value)
-                                                    {:times-to-try 2})
+             (cljtest/match? "contains with monadic left value"
+                             (state/gets :value)
+                             (matchers/equals {:n 1})
+                             {:times-to-try 2})
              {:value {:n 2}})]
         (testing "returns actual"
           (is (= {:n 2} flow-ret)))
@@ -68,8 +69,8 @@
             (test-helpers/run-flow
              (flow "flow"
                (test-helpers/delayed-add-two 200)
-               (assertions.matcher-combinators/match? 2 get-value-state {:times-to-try 2
-                                                                         :sleep-time 75}))
+               (cljtest/match? "2" get-value-state 2 {:times-to-try 2
+                                                      :sleep-time 75}))
              {:value (atom 0)})]
         (testing "returns actual (derived from state)"
           (is (= 0 flow-ret)))
@@ -82,50 +83,51 @@
 ;; in the deftest below causes test failures. I think it has to do with calling macroexpand
 ;; within a macro body.
 (def flow-with-defaults
-  (macroexpand-1 '(defflow my-flow (assertions.matcher-combinators/match? 1 1))))
+  (macroexpand-1 '(defflow my-flow (cljtest/match? "equals" 1 1))))
 (def flow-with-optional-args
-  (macroexpand-1 '(defflow my-flow {:init (constantly {:value 1})} (assertions.matcher-combinators/match? 1 1))))
+  (macroexpand-1 '(defflow my-flow {:init (constantly {:value 1})} (cljtest/match? "equals" 1 1))))
 (def flow-with-binding-and-match
   (macroexpand-1 '(defflow my-flow {:init (constantly {:value 1
                                                        :map {:a 1 :b 2}})}
                     [value (state/gets :value)]
-                    (assertions.matcher-combinators/match? value 1)
-                    (assertions.matcher-combinators/match? (state/gets :map) {:b 2}))))
+                    (cljtest/match? value 1)
+                    (cljtest/match? (state/gets :map) {:b 2}))))
 
 (deftest test-defflow
   (testing "defines flow with default parameters"
     (is (= '(clojure.test/deftest
               my-flow
               (state-flow.core/run*
-               {}
-               (state-flow.core/flow "my-flow" (assertions.matcher-combinators/match? 1 1))))
+                {}
+                (state-flow.core/flow "my-flow" (cljtest/match? "equals" 1 1))))
            flow-with-defaults)))
 
   (testing "defines flow with optional parameters"
     (is (= '(clojure.test/deftest
               my-flow
               (state-flow.core/run*
-               {:init (constantly {:value 1})}
-               (state-flow.core/flow "my-flow" (assertions.matcher-combinators/match? 1 1))))
+                {:init (constantly {:value 1})}
+                (state-flow.core/flow "my-flow" (cljtest/match? "equals" 1 1))))
            flow-with-optional-args)))
 
   (testing "defines flow with binding and flow inside match?"
     (is (= '(clojure.test/deftest
               my-flow
               (state-flow.core/run*
-               {:init (constantly {:map {:a 1 :b 2} :value 1})}
-               (state-flow.core/flow
-                "my-flow"
-                 [value (state/gets :value)]
-                 (assertions.matcher-combinators/match? value 1)
-                 (assertions.matcher-combinators/match? (state/gets :map) {:b 2}))))
+                {:init (constantly {:map {:a 1 :b 2} :value 1})}
+                (state-flow.core/flow
+                  "my-flow"
+                  [value (state/gets :value)]
+                  (cljtest/match? value 1)
+                  (cljtest/match? (state/gets :map) {:b 2}))))
+
            flow-with-binding-and-match))))
 
 (defflow my-flow {:init (constantly {:value 1
                                      :map   {:a 1 :b 2}})}
   [value (state/gets :value)]
-  (assertions.matcher-combinators/match? 1 value)
-  (assertions.matcher-combinators/match? {:b 2} (state/gets :map)))
+  (cljtest/match? "1" value 1)
+  (cljtest/match? "b is 2" (state/gets :map) {:b 2}))
 
 (deftest run-a-flow
   (is (match? {:value 1

--- a/test/state_flow/cljtest_test.clj
+++ b/test/state_flow/cljtest_test.clj
@@ -28,7 +28,7 @@
 
     (testing "with explicit matcher for expected"
       (let [[ret state] (state-flow/run (assertions.matcher-combinators/match? (matchers/equals 3)
-                                                    test-helpers/add-two) {:value 1})]
+                                                                               test-helpers/add-two) {:value 1})]
         (testing "returns actual (derived from state)"
           (is (= 3 ret)))
         (testing "doesn't change state"
@@ -40,7 +40,7 @@
              (flow "flow"
                (test-helpers/delayed-add-two 100)
                (assertions.matcher-combinators/match? 2 get-value-state {:times-to-try 2
-                                              :sleep-time 110}))
+                                                                         :sleep-time 110}))
              {:value (atom 0)})]
         (testing "returns actual (derived from state)"
           (is (= 2 flow-ret))))))
@@ -51,8 +51,8 @@
             {:keys [flow-ret flow-state report-data]}
             (test-helpers/run-flow
              (assertions.matcher-combinators/match? (matchers/equals {:n 1})
-                         (state/gets :value)
-                         {:times-to-try 2})
+                                                    (state/gets :value)
+                                                    {:times-to-try 2})
              {:value {:n 2}})]
         (testing "returns actual"
           (is (= {:n 2} flow-ret)))
@@ -69,7 +69,7 @@
              (flow "flow"
                (test-helpers/delayed-add-two 200)
                (assertions.matcher-combinators/match? 2 get-value-state {:times-to-try 2
-                                              :sleep-time 75}))
+                                                                         :sleep-time 75}))
              {:value (atom 0)})]
         (testing "returns actual (derived from state)"
           (is (= 0 flow-ret)))
@@ -97,30 +97,29 @@
     (is (= '(clojure.test/deftest
               my-flow
               (state-flow.core/run*
-                {}
-                (state-flow.core/flow "my-flow" (assertions.matcher-combinators/match? 1 1))))
+               {}
+               (state-flow.core/flow "my-flow" (assertions.matcher-combinators/match? 1 1))))
            flow-with-defaults)))
 
   (testing "defines flow with optional parameters"
     (is (= '(clojure.test/deftest
               my-flow
               (state-flow.core/run*
-                {:init (constantly {:value 1})}
-                (state-flow.core/flow "my-flow" (assertions.matcher-combinators/match? 1 1))))
+               {:init (constantly {:value 1})}
+               (state-flow.core/flow "my-flow" (assertions.matcher-combinators/match? 1 1))))
            flow-with-optional-args)))
 
   (testing "defines flow with binding and flow inside match?"
     (is (= '(clojure.test/deftest
               my-flow
               (state-flow.core/run*
-                {:init (constantly {:map {:a 1 :b 2} :value 1})}
-                (state-flow.core/flow
-                  "my-flow"
-                  [value (state/gets :value)]
-                  (assertions.matcher-combinators/match? value 1)
-                  (assertions.matcher-combinators/match? (state/gets :map) {:b 2}))))
+               {:init (constantly {:map {:a 1 :b 2} :value 1})}
+               (state-flow.core/flow
+                "my-flow"
+                 [value (state/gets :value)]
+                 (assertions.matcher-combinators/match? value 1)
+                 (assertions.matcher-combinators/match? (state/gets :map) {:b 2}))))
            flow-with-binding-and-match))))
-
 
 (defflow my-flow {:init (constantly {:value 1
                                      :map   {:a 1 :b 2}})}

--- a/test/state_flow/cljtest_test.clj
+++ b/test/state_flow/cljtest_test.clj
@@ -2,8 +2,9 @@
   (:require [clojure.test :as t :refer [deftest testing is]]
             [matcher-combinators.test :refer [match?]]
             [matcher-combinators.matchers :as matchers]
+            [state-flow.assertions.matcher-combinators :as assertions.matcher-combinators]
             [state-flow.test-helpers :as test-helpers :refer [this-line-number]]
-            [state-flow.cljtest :as cljtest :refer [defflow]]
+            [state-flow.cljtest :refer [defflow]]
             [state-flow.core :as state-flow :refer [flow]]
             [state-flow.state :as state]))
 
@@ -12,23 +13,22 @@
 (deftest test-match?
   (testing "passing cases"
     (testing "with literals for expected and actual"
-      (let [[ret state] (state-flow/run (cljtest/match? "DESC" 3 3) {:initial :state})]
+      (let [[ret state] (state-flow/run (testing "DESC" (assertions.matcher-combinators/match? 3 3)) {:initial :state})]
         (testing "returns actual (literal)"
           (is (= 3 ret)))
         (testing "doesn't change state"
           (is (= {:initial :state} state)))))
 
     (testing "with state monad for actual"
-      (let [[ret state] (state-flow/run (cljtest/match? "DESC" test-helpers/add-two 3) {:value 1})]
+      (let [[ret state] (state-flow/run (testing "DESC" (assertions.matcher-combinators/match? 3 test-helpers/add-two)) {:value 1})]
         (testing "returns actual (derived from state)"
           (is (= 3 ret)))
         (testing "doesn't change state"
           (is (= {:value 1} state)))))
 
     (testing "with explicit matcher for expected"
-      (let [[ret state] (state-flow/run (cljtest/match? "DESC"
-                                                        test-helpers/add-two
-                                                        (matchers/equals 3)) {:value 1})]
+      (let [[ret state] (state-flow/run (testing "DESC" (assertions.matcher-combinators/match? (matchers/equals 3)
+                                                                                               test-helpers/add-two)) {:value 1})]
         (testing "returns actual (derived from state)"
           (is (= 3 ret)))
         (testing "doesn't change state"
@@ -39,8 +39,8 @@
             (test-helpers/run-flow
              (flow "flow"
                (test-helpers/delayed-add-two 100)
-               (cljtest/match? "2" get-value-state 2 {:times-to-try 2
-                                                      :sleep-time 110}))
+               (testing "2" (assertions.matcher-combinators/match? 2 get-value-state {:times-to-try 2
+                                                                                      :sleep-time 110})))
              {:value (atom 0)})]
         (testing "returns actual (derived from state)"
           (is (= 2 flow-ret))))))
@@ -50,10 +50,9 @@
       (let [three-lines-before-call-to-match (this-line-number)
             {:keys [flow-ret flow-state report-data]}
             (test-helpers/run-flow
-             (cljtest/match? "contains with monadic left value"
-                             (state/gets :value)
-                             (matchers/equals {:n 1})
-                             {:times-to-try 2})
+             (testing "contains with monadic left value" (assertions.matcher-combinators/match? (matchers/equals {:n 1})
+                                                                                                (state/gets :value)
+                                                                                                {:times-to-try 2}))
              {:value {:n 2}})]
         (testing "returns actual"
           (is (= {:n 2} flow-ret)))
@@ -69,8 +68,8 @@
             (test-helpers/run-flow
              (flow "flow"
                (test-helpers/delayed-add-two 200)
-               (cljtest/match? "2" get-value-state 2 {:times-to-try 2
-                                                      :sleep-time 75}))
+               (testing "2" (assertions.matcher-combinators/match? 2 get-value-state {:times-to-try 2
+                                                                                      :sleep-time 75})))
              {:value (atom 0)})]
         (testing "returns actual (derived from state)"
           (is (= 0 flow-ret)))
@@ -83,51 +82,51 @@
 ;; in the deftest below causes test failures. I think it has to do with calling macroexpand
 ;; within a macro body.
 (def flow-with-defaults
-  (macroexpand-1 '(defflow my-flow (cljtest/match? "equals" 1 1))))
+  (macroexpand-1 '(defflow my-flow (testing "equals" (assertions.matcher-combinators/match? 1 1)))))
 (def flow-with-optional-args
-  (macroexpand-1 '(defflow my-flow {:init (constantly {:value 1})} (cljtest/match? "equals" 1 1))))
+  (macroexpand-1 '(defflow my-flow {:init (constantly {:value 1})} (testing "equals" (assertions.matcher-combinators/match? 1 1)))))
 (def flow-with-binding-and-match
   (macroexpand-1 '(defflow my-flow {:init (constantly {:value 1
                                                        :map {:a 1 :b 2}})}
                     [value (state/gets :value)]
-                    (cljtest/match? value 1)
-                    (cljtest/match? (state/gets :map) {:b 2}))))
+                    (testing "1" (assertions.matcher-combinators/match? 1 value))
+                    (testing "b is 2" (assertions.matcher-combinators/match? {:b 2} (state/gets :map))))))
 
 (deftest test-defflow
   (testing "defines flow with default parameters"
     (is (= '(clojure.test/deftest
               my-flow
               (state-flow.core/run*
-                {}
-                (state-flow.core/flow "my-flow" (cljtest/match? "equals" 1 1))))
+               {}
+               (state-flow.core/flow "my-flow" (testing "equals" (assertions.matcher-combinators/match? 1 1)))))
            flow-with-defaults)))
 
   (testing "defines flow with optional parameters"
     (is (= '(clojure.test/deftest
               my-flow
               (state-flow.core/run*
-                {:init (constantly {:value 1})}
-                (state-flow.core/flow "my-flow" (cljtest/match? "equals" 1 1))))
+               {:init (constantly {:value 1})}
+               (state-flow.core/flow "my-flow" (testing "equals" (assertions.matcher-combinators/match? 1 1)))))
            flow-with-optional-args)))
 
   (testing "defines flow with binding and flow inside match?"
     (is (= '(clojure.test/deftest
               my-flow
               (state-flow.core/run*
-                {:init (constantly {:map {:a 1 :b 2} :value 1})}
-                (state-flow.core/flow
-                  "my-flow"
-                  [value (state/gets :value)]
-                  (cljtest/match? value 1)
-                  (cljtest/match? (state/gets :map) {:b 2}))))
+               {:init (constantly {:map {:a 1 :b 2} :value 1})}
+               (state-flow.core/flow
+                "my-flow"
+                 [value (state/gets :value)]
+                 (testing "1" (assertions.matcher-combinators/match? 1 value))
+                 (testing "b is 2" (assertions.matcher-combinators/match? {:b 2} (state/gets :map))))))
 
            flow-with-binding-and-match))))
 
 (defflow my-flow {:init (constantly {:value 1
                                      :map   {:a 1 :b 2}})}
   [value (state/gets :value)]
-  (cljtest/match? "1" value 1)
-  (cljtest/match? "b is 2" (state/gets :map) {:b 2}))
+  (testing "1" (assertions.matcher-combinators/match? 1 value))
+  (testing "b is 2" (assertions.matcher-combinators/match? {:b 2} (state/gets :map))))
 
 (deftest run-a-flow
   (is (match? {:value 1

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -41,7 +41,7 @@
     (let [[l r] (state-flow/run (flow "flow"
                                   (flow "step 1" add-two)
                                   (flow "step 2" add-two))
-                  {:value 0})]
+                                {:value 0})]
       (is (= {:value 4} r))
       (is (= "flow" (state-flow/top-level-description r)))))
 
@@ -57,8 +57,8 @@
 
   (testing "flow with a `(str ..)` expr for the description is fine"
     (is (macroexpand `(flow (str "foo") [original (state/gets :value)
-                                                    :let [doubled (* 2 original)]]
-                        (state/modify #(assoc % :value doubled))))))
+                                         :let [doubled (* 2 original)]]
+                            (state/modify #(assoc % :value doubled))))))
 
   (testing "but flows with an expression that resolves to a string also aren't valid,
             due to resolution limitations at macro-expansion time"
@@ -66,8 +66,8 @@
                  (let [my-desc "trolololo"]
                    (try
                      (macroexpand `(flow ~'my-desc [original (state/gets :value)
-                                                               :let [doubled (* 2 original)]]
-                                     (state/modify #(assoc % :value doubled))))
+                                                    :let [doubled (* 2 original)]]
+                                         (state/modify #(assoc % :value doubled))))
                      (catch clojure.lang.Compiler$CompilerException e
                        (.. e getCause getMessage)))))))
 
@@ -91,7 +91,7 @@
          (-> (state-flow/run* {:init    (constantly {:value 0
                                                      :atom  (atom 1)})
                                :cleanup #(reset! (:atom %) 0)}
-               nested-flow)
+                              nested-flow)
              second
              :atom
              deref))))
@@ -101,7 +101,7 @@
                 (-> (state-flow/run* {:init   (constantly {:value 0})
                                       :runner (fn [flow state]
                                                 [nil (state-flow/run flow state)])}
-                      nested-flow)
+                                     nested-flow)
                     second
                     second)))))
 
@@ -183,19 +183,19 @@
   (testing "after nested flows complete"
     (testing "within nested flows "
       (is (re-matches #"level 1 \(line \d+\)"
-             (first (state-flow/run (flow "level 1"
-                                      (flow "level 2")
-                                      (state-flow/current-description))))))
+                      (first (state-flow/run (flow "level 1"
+                                               (flow "level 2")
+                                               (state-flow/current-description))))))
       (is (re-matches #"level 1 \(line \d+\) -> level 2 \(line \d+\)"
-             (first (state-flow/run (flow "level 1"
-                                      (flow "level 2"
-                                        (flow "level 3")
-                                        (state-flow/current-description)))))))
+                      (first (state-flow/run (flow "level 1"
+                                               (flow "level 2"
+                                                 (flow "level 3")
+                                                 (state-flow/current-description)))))))
       (is (re-matches #"level 1 \(line \d+\)"
-             (first (state-flow/run (flow "level 1"
-                                      (flow "level 2"
-                                        (flow "level 3"))
-                                      (state-flow/current-description)))))))))
+                      (first (state-flow/run (flow "level 1"
+                                               (flow "level 2"
+                                                 (flow "level 3"))
+                                               (state-flow/current-description)))))))))
 
 (deftest top-level-description
   (let [tld (fn [flow] (->> (state-flow/run flow)
@@ -222,9 +222,9 @@
                       .getMessage)))
     (is (re-find #"Expected a flow.*got.*identity"
                  (->> (state-flow/run
-                        (flow "flow"
-                          [x identity]
-                          (state/gets)))
+                       (flow "flow"
+                         [x identity]
+                         (state/gets)))
                       first
                       :failure
                       .getMessage)))))

--- a/test/state_flow/probe_test.clj
+++ b/test/state_flow/probe_test.clj
@@ -27,4 +27,4 @@
              (first (state-flow/run (probe/probe test-helpers/get-value-state #(= 2 %)
                                                  {:sleep-time   250
                                                   :times-to-try 5})
-                      state)))))))
+                                    state)))))))

--- a/test/state_flow/refactoring_tools/refactor_match_test.clj
+++ b/test/state_flow/refactoring_tools/refactor_match_test.clj
@@ -1,0 +1,56 @@
+(ns state-flow.refactoring-tools.refactor-match-test
+  (:require [clojure.test :as t :refer [deftest testing is]]
+            [clojure.edn :as edn]
+            [rewrite-clj.zip :as z]
+            [state-flow.refactoring-tools.refactor-match :as refactor-match]))
+
+(defn zip [expr]
+  (z/of-string (str expr)))
+
+(defn unzip [zipper]
+  (edn/read-string (z/root-string zipper)))
+
+(deftest refactor-match-expr
+  (is (= '(after/match? expected actual)
+         (unzip
+          (refactor-match/refactor-match-expr
+           {:sym-after 'after/match?}
+           (zip '(after/match? "description" actual expected))))))
+
+  (testing "with wrap-in-testing option"
+    (is (= '(testing "description" (after/match? expected actual))
+           (unzip
+            (refactor-match/refactor-match-expr
+             {:wrap-in-testing true
+              :sym-after 'after/match?}
+             (zip '(before/match? "description" actual expected))))))))
+
+(deftest refactor-all
+  (testing "at root"
+    (is (= "(after/match? expected actual)"
+           (refactor-match/refactor-all
+            {:str "(before/match? \"description\" actual expected)"
+             :sym-before 'before/match?
+             :sym-after 'after/match?}))))
+
+  (testing "in deftest"
+    (is (= "(deftest thing (after/match? expected actual))"
+           (refactor-match/refactor-all
+            {:str "(deftest thing (before/match? \"description\" actual expected))"
+             :sym-before 'before/match?
+             :sym-after 'after/match?}))))
+
+  (testing "multiple matches"
+    (is (= "(deftest thing (after/match? expected actual)\n  (after/match? expected2 actual2))"
+           (refactor-match/refactor-all
+            {:str "(deftest thing (before/match? \"description\" actual expected)\n  (before/match? \"description\" actual2 expected2))"
+             :sym-before 'before/match?
+             :sym-after 'after/match?}))))
+
+  (testing "wrapped in testing"
+    (is (= "(deftest thing (testing \"description\" (after/match? expected actual)))"
+           (refactor-match/refactor-all
+            {:str "(deftest thing (before/match? \"description\" actual expected))"
+             :sym-before 'before/match?
+             :sym-after 'after/match?
+             :wrap-in-testing true})))))

--- a/test/state_flow/refactoring_tools/refactor_match_test.clj
+++ b/test/state_flow/refactoring_tools/refactor_match_test.clj
@@ -17,11 +17,11 @@
            {:sym-after 'after/match?}
            (zip '(after/match? "description" actual expected))))))
 
-  (testing "with wrap-in-testing option"
-    (is (= '(testing "description" (after/match? expected actual))
+  (testing "with wrap-in-flow option"
+    (is (= '(flow "description" (after/match? expected actual))
            (unzip
             (refactor-match/refactor-match-expr
-             {:wrap-in-testing true
+             {:wrap-in-flow true
               :sym-after 'after/match?}
              (zip '(before/match? "description" actual expected))))))))
 
@@ -47,10 +47,10 @@
              :sym-before 'before/match?
              :sym-after 'after/match?}))))
 
-  (testing "wrapped in testing"
-    (is (= "(deftest thing (testing \"description\" (after/match? expected actual)))"
+  (testing "with wrap-in-flow option"
+    (is (= "(deftest thing (flow \"description\" (after/match? expected actual)))"
            (refactor-match/refactor-all
             {:str "(deftest thing (before/match? \"description\" actual expected))"
              :sym-before 'before/match?
              :sym-after 'after/match?
-             :wrap-in-testing true})))))
+             :wrap-in-flow true})))))

--- a/test/state_flow/state_test.clj
+++ b/test/state_flow/state_test.clj
@@ -14,7 +14,7 @@
     (state/put {:count 0}))
   (let [increment-state (m/mlet [x (state/get)
                                  _ (state/put (inc x))]
-                                (m/return x))
+                          (m/return x))
         double-state    (state/modify #(* 2 %))]
     (testing "modify state with get and put"
       (is (= [2 3]

--- a/test/state_flow/test_helpers.clj
+++ b/test/state_flow/test_helpers.clj
@@ -18,11 +18,9 @@
   [delay-ms]
   "Changes state in the future"
   (state/modify (fn [state]
-                      (future (do (Thread/sleep delay-ms)
-                                  (swap! (:value state) + 2)))
-                      state)))
-
-
+                  (future (do (Thread/sleep delay-ms)
+                              (swap! (:value state) + 2)))
+                  state)))
 
 (defmacro run-flow
   "Wrapper for `state-flow.core/run!`, but captures clojure.test's report data


### PR DESCRIPTION
RFC

This PR introduces `state-flow.assertions.matcher-combinators/match?` and deprecates `state-flow.cljtest/match?`.

### Rationale:
The existing `match?` fn takes `[description actual expected & [params]]`. 

In most cases, the `description` is redundant, so we're removing it from the API. If you want a description that is more informative than the default (you can see the expected value in the code and in the failure output), you can always wrap `match?` in a flow with a description.

The order (actual, then expected) is the reverse of clojure.test assertions and, consequently, the `match?` assert expression provided by matcher-combinators for use in clojure.test tests.

### Open questions

* Is `state-flow.assertions.xxx` a good idea?
  * yes, per discussion below
* Should we support `:description` in the `params` argument to `match?`? It works as of this PR in order to support the deprecated `cljtest/match?` fn with minimal duplication.
  * no - the refactoring tool gives the option to wrap it in a `flow` with a description
* As long as we're supporting the deprecated version, should we maintain a separate set of tests for it?

### TODO

* [x] add tools to migrate from old `match?` to new `match?`
* [ ] decouple `match?` from clojure.test (in a future PR)


