### PR TITLE
Enhance state/modify and state/gets to accept varargs (and apply args to fn)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
+## [DEV]
+
+- state-flow.state/modify and state-flow.state/gets pass additional args to f
+
 ## [2.2.3]
- - Revert changes in `2.2.2` until a few issues are resolved
+
+- Revert changes in `2.2.2` until a few issues are resolved
 
 ## [2.2.2]
 

--- a/doc/walkthrough.repl
+++ b/doc/walkthrough.repl
@@ -72,7 +72,18 @@
 (run (state/modify (fn [s] (update s :count inc))) {:count 0})
 ;; => [{:count 0} {:count 1}]
 ;;
-;; Or we can replace the internal state entirely, returning the previous state:
+;; `modify` and `gets` each pass additional args to the function,
+;; so this `modify` could look like this, instead:
+
+(run (state/modify update :count inc) {:count 0})
+;; => [{:count 0} {:count 1}]
+
+;; ... and the `gets`, above, could look like this:
+
+(run (state/gets update :count inc) {:count 0})
+;; => [{:count 1} {:count 0}]
+
+;; We can also replace the internal state entirely, returning the previous state:
 
 (run (state/put {:name "Jacob"}) {:count 0})
 ;; => [{:count 0} {:name "Jacob"}]
@@ -84,18 +95,18 @@
 ;; We use flows to string together several steps in a single step:
 
 (flow "counter"
-      (state/modify (fn [s] (update s :count inc)))
-      (state/modify (fn [s] (update s :count inc)))
-      (state/modify (fn [s] (update s :count inc))))
+  (state/modify update :count inc)
+  (state/modify update :count inc)
+  (state/modify update :count inc))
 ;; => #cats.monad.state.State{:mfn #object[...],
 ;;                            :state-context #<State-E>}
 ;;
 ;; And, then we can hand that directly to the run function:
 
 (run (flow "counter"
-           (state/modify (fn [s] (update s :count inc)))
-           (state/modify (fn [s] (update s :count inc)))
-           (state/modify (fn [s] (update s :count inc))))
+       (state/modify update :count inc)
+       (state/modify update :count inc)
+       (state/modify update :count inc))
   {:count 0})
 ;; => [{:count 2} {:count 3}]
 ;;
@@ -107,12 +118,12 @@
 ;;
 
 ;; (run (flow "counter"
-;;            (state/modify (fn [s] (update s :count inc)))
-;;            ^^ fn is invoked with {:count 0}, produces [{:count 0} {:count 1}]
-;;            (state/modify (fn [s] (update s :count inc)))  ;; => [{:count 1} {:count 2}]
-;;            ^^ fn is invoked with {:count 1}, produces [{:count 1} {:count 2}]
-;;            (state/modify (fn [s] (update s :count inc)))) ;; => [{:count 2} {:count 3}]
-;;            ^^ fn is invoked with {:count 2}, produces [{:count 2} {:count 3}]
+;;        (state/modify update :count inc)
+;;        ^^ fn is invoked with {:count 0}, produces [{:count 0} {:count 1}]
+;;        (state/modify update :count inc)
+;;        ^^ fn is invoked with {:count 1}, produces [{:count 1} {:count 2}]
+;;        (state/modify update :count inc)
+;;        ^^ fn is invoked with {:count 2}, produces [{:count 2} {:count 3}]
 ;;   {:count 0})
 ;; => [{:count 2} {:count 3}]
 ;;    ^^ the value produced by the last invocation within the flow
@@ -129,7 +140,7 @@
 ;; Since steps and flows are state monads, which are values, we can use all
 ;; the familiar tools of Clojure to define and compose them.
 
-(def inc-count (state/modify (fn [s] (update s :count inc))))
+(def inc-count (state/modify update :count inc))
 
 (def inc-twice
   (flow "increment twice"
@@ -148,7 +159,7 @@
               inc-twice
               (flow "inc 2 more times (grandchild)"
                     inc-twice))
-        (state/gets (fn [s] (update s :count * 3))))
+    (state/gets update :count * 3))
   {:count 0})
 ;; => [{:count 15} {:count 5}]
 
@@ -176,7 +187,7 @@
 (run
   (flow "binding example"
         [:let [start 37]]
-        (state/modify (fn [s] (update s :count + start)))
+        (state/modify update :count + start)
         (state/gets :count))
   {:count 0})
 ;; => [37 {:count 37}]
@@ -186,7 +197,7 @@
 (run
   (flow "binding example"
         [:let [start (+ 30 7)]]
-        (state/modify (fn [s] (update s :count + start)))
+        (state/modify update :count + start)
         (state/gets :count))
   {:count 0})
 ;; => [37 {:count 37}]

--- a/src/state_flow/state.clj
+++ b/src/state_flow/state.clj
@@ -64,9 +64,9 @@
   (state/get error-context))
 
 (defn gets
-  [f]
-  "Returns the equivalent of (fn [state] [state, (f state)])"
-  (state/gets f error-context))
+  [f & args]
+  "Returns the equivalent of (fn [state] [state, (apply f state args)])"
+  (state/gets #(apply f % args) error-context))
 
 (defn put
   "Returns the equivalent of (fn [state] [state, new-state])"
@@ -74,9 +74,9 @@
   (state/put new-state error-context))
 
 (defn modify
-  "Returns the equivalent of (fn [state] [state, (swap! state f)])"
-  [f]
-  (state/swap f error-context))
+  "Returns the equivalent of (fn [state] [state, (apply swap! state f args)])"
+  [f & args]
+  (state/swap #(apply f % args) error-context))
 
 (defn return
   "Returns the equivalent of (fn [state] [v, state])"

--- a/test/state_flow/state_test.clj
+++ b/test/state_flow/state_test.clj
@@ -5,27 +5,40 @@
             [cats.monad.exception :as e]
             [state-flow.state :as state]))
 
-(deftest state
+(deftest primitives
   (testing "primitives are constructable outside monad context"
-    (state/get)
-    (state/gets inc)
-    (state/modify inc)
-    (state/return 37)
-    (state/put {:count 0}))
-  (let [increment-state (m/mlet [x (state/get)
-                                 _ (state/put (inc x))]
-                                (m/return x))
-        double-state    (state/modify #(* 2 %))]
-    (testing "modify state with get and put"
-      (is (= [2 3]
-             (state/run increment-state 2))))
-    (testing "modify state with modify"
-      (is (= [2 4]
-             (state/run double-state 2))))
-    (testing "state with an exception"
+    (is (state/get))
+    (is (state/gets inc))
+    (is (state/modify inc))
+    (is (state/return 37))
+    (is (state/put {:count 0}))))
+
+(deftest exception-handling
+  (let [double-state (state/modify * 2)]
+    (testing "state with an exception returns a failure as the left value"
       (let [[res state] (state/run (m/>> double-state
                                          double-state
                                          (state/modify (fn [s] (throw (Exception. "My exception"))))
                                          double-state) 2)]
         (is (e/failure? res))
         (is (= 8 state))))))
+
+(deftest get-and-put
+  (let [increment-state (m/mlet [x (state/get)
+                                 _ (state/put (inc x))]
+                                (m/return x))]
+    (testing "modify state with get and put"
+      (is (= [2 3]
+             (state/run increment-state 2))))))
+
+(deftest modify
+  (testing "supports single function or varargs"
+    (is (= [{:count 0} {:count 1}]
+           (state/run (state/modify #(update % :count inc)) {:count 0})
+           (state/run (state/modify update :count inc) {:count 0})))))
+
+(deftest gets
+  (testing "supports single function or varargs"
+    (is (= [{:count 1} {:count 0}]
+           (state/run (state/gets #(update % :count inc)) {:count 0})
+           (state/run (state/gets update :count inc) {:count 0})))))


### PR DESCRIPTION
This PR makes the higher order functions `state-flow.state/modify` and `state-flow.state/gets` work more like e.g. Clojure's swap!, update, etc, in order to support more idiomatic Clojure

```
(state/gets #(update % :count inc))
(state/modify #(update % :count inc))

;; can now also be expressed ...

(state/gets update :count inc)
(state/modify update :count inc)
```



