### PR TITLE
improve `match?` refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.2.5]
+
+- add shell script to refactor match? expressions and `:require [state-flow.cljtest} ...`
+
 ## [2.2.4]
 
 - state-flow.state/modify and state-flow.state/gets pass additional args to f

--- a/README.md
+++ b/README.md
@@ -216,12 +216,23 @@ We also reversed the order of expected and actual in order to align
 with the `match?` function in the matcher-combinators library and with
 clojure.test's `(is (= expected actual))`.
 
-In order to ease refactoring, we also added a `refactor-match`
-function, which takes a path to a file and some configuration options
-about what you want the refactoring to do.
+We also added a script to help refactor this for you. Here's how
+you use it:
 
-See the `state-flow.refactoring-tools.refactor-match` ns for
-details.
+``` shell
+# if you don't already have this repo cloned
+git clone https://github.com/nubank/state-flow.git
+cd state-flow
+
+# if you already have this repo cloned
+cd state-flow
+git co master
+git pull
+
+# the rest is the same either way
+bin/refactor-match --help
+;; now follow the instructions
+```
 
 ## Midje Support
 

--- a/bin/refactor-match.sh
+++ b/bin/refactor-match.sh
@@ -2,7 +2,7 @@
 #_(
    DEPS='
    {:deps {rewrite-clj {:mvn/version "0.6.1"}
-           nubank/state-flow {:mvn/version "2.2.4"}}}
+           nubank/state-flow {:mvn/version "2.2.5"}}}
    '
    exec clojure -Sdeps "$DEPS" "$0" "$@"
 )

--- a/bin/refactor-match.sh
+++ b/bin/refactor-match.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+#_(
+   DEPS='
+   {:deps {rewrite-clj {:mvn/version "0.6.1"}
+           nubank/state-flow {:mvn/version "2.2.4"}}}
+   '
+   exec clojure -Sdeps "$DEPS" "$0" "$@"
+)
+
+(require '[rewrite-clj.zip :as z]
+         '[state-flow.refactoring-tools.refactor-match :as refactor-match])
+
+(defn opt-value [opts opt-name]
+ (->> opts (drop-while (complement #(= opt-name %))) (drop 1) first))
+
+
+(defn -main
+ [path & opts]
+ (let [arg-map {:path path
+                :rewrite (contains? (set opts) "--rewrite")
+                :wrap-in-flow (contains? (set opts) "--wrap-in-flow")
+                :force-probe-params (contains? (set opts) "--force-probe-params")
+                :sym-before (if-let [sym-before (opt-value opts "--sym-before")]
+                              (symbol sym-before)
+                              'match?)
+                :sym-after (if-let [sym-after (opt-value opts "--sym-after")]
+                             (symbol sym-after)
+                             'match? )}]
+  (println (str "Processing " path "..."))
+  (prn arg-map)
+  (refactor-match/refactor-require (select-keys arg-map [:path :rewrite]))
+  (refactor-match/refactor-match-exprs arg-map)))
+
+(apply -main *command-line-args*)

--- a/bin/refactor-match.sh
+++ b/bin/refactor-match.sh
@@ -7,28 +7,37 @@
    exec clojure -Sdeps "$DEPS" "$0" "$@"
 )
 
-(require '[rewrite-clj.zip :as z]
+(require '[clojure.string :as str]
+         '[rewrite-clj.zip :as z]
          '[state-flow.refactoring-tools.refactor-match :as refactor-match])
 
 (defn opt-value [opts opt-name]
  (->> opts (drop-while (complement #(= opt-name %))) (drop 1) first))
 
-
 (defn -main
- [path & opts]
- (let [arg-map {:path path
-                :rewrite (contains? (set opts) "--rewrite")
-                :wrap-in-flow (contains? (set opts) "--wrap-in-flow")
-                :force-probe-params (contains? (set opts) "--force-probe-params")
-                :sym-before (if-let [sym-before (opt-value opts "--sym-before")]
-                              (symbol sym-before)
-                              'match?)
-                :sym-after (if-let [sym-after (opt-value opts "--sym-after")]
-                             (symbol sym-after)
-                             'match? )}]
-  (println (str "Processing " path "..."))
-  (prn arg-map)
-  (refactor-match/refactor-require (select-keys arg-map [:path :rewrite]))
-  (refactor-match/refactor-match-exprs arg-map)))
+  [& path-and-opts]
+  (let [path (first path-and-opts)
+        opts (rest path-and-opts)]
+    (if (or (nil? path) (contains? (set path-and-opts) "--help"))
+      (println
+       (str/join "\n"
+                 ["Usage"
+                  ""
+                  "bin/refactor-match.sh <path> [--rewrite] [--wrap-in-flow] [--force-probe-params] [--sym-before <sym-before>] [--sym-after <sym-after>]"
+                  ""]))
+      (let [arg-map {:path path
+                     :rewrite (contains? (set opts) "--rewrite")
+                     :wrap-in-flow (contains? (set opts) "--wrap-in-flow")
+                     :force-probe-params (contains? (set opts) "--force-probe-params")
+                     :sym-before (if-let [sym-before (opt-value opts "--sym-before")]
+                                   (symbol sym-before)
+                                   'match?)
+                     :sym-after (if-let [sym-after (opt-value opts "--sym-after")]
+                                  (symbol sym-after)
+                                  'match? )}]
+        (println (str "Processing " path "..."))
+        (prn arg-map)
+        (refactor-match/refactor-require (select-keys arg-map [:path :rewrite]))
+        (refactor-match/refactor-match-exprs arg-map)))))
 
-(apply -main *command-line-args*)
+  (apply -main *command-line-args*)

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "2.2.4"
+(defproject nubank/state-flow "2.2.5"
   :description "Postman-like integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}

--- a/src/state_flow/refactoring_tools/refactor_match.clj
+++ b/src/state_flow/refactoring_tools/refactor_match.clj
@@ -46,6 +46,7 @@
                   (z/replace
                    (-> (z/of-string "(flow)")
                        (z/append-child (z/node desc))
+                       (z/append-child (n/newlines 1))
                        (z/append-child (z/node refactored))
                        (z/node))))
         refactored))

--- a/src/state_flow/refactoring_tools/refactor_match.clj
+++ b/src/state_flow/refactoring_tools/refactor_match.clj
@@ -52,25 +52,26 @@
         refactored))
     (catch Exception e
       (println "Error processing " (z/string zloc))
+      (println e)
       zloc)))
 
 (defn match-expr? [match-sym node]
   (when (= :list (z/tag node))
     (when-let [op (z/down node)]
-      (= match-sym (z/value op)))))
+      (= match-sym (z/sexpr op)))))
 
-(defn ^:private refactor-all* [{:keys [sym-before] :as opts} data]
-  (loop [data data]
+(defn ^:private refactor-match-exprs* [{:keys [sym-before] :as opts} zloc]
+  (loop [zloc zloc]
     (let [updated (try
-                    (z/prewalk data
+                    (z/postwalk zloc
                                (partial match-expr? sym-before)
                                (partial refactor-match-expr opts))
-                    (catch Exception _ data))]
+                    (catch Exception _ zloc))]
       (if (z/rightmost? updated)
         updated
         (recur (z/right updated))))))
 
-(defn refactor-all
+(defn refactor-match-exprs
   "Given a map with :path to a file or a string :str, returns
   a string with all of the match? expressions refactored as follows:
 
@@ -132,14 +133,54 @@
                         opts)
         z-before (or (and path (z/of-file path))
                      (and str (z/of-string str)))
-        z-after  (z/root-string (refactor-all* opts* z-before))]
+        z-after  (z/root-string (refactor-match-exprs* opts* z-before))]
+    (if (and path rewrite)
+      (spit (io/file path) z-after)
+      z-after)))
+
+(defn old-require? [zloc]
+  (and (= :require (-> zloc z/leftmost z/sexpr))
+       (= :vector (-> zloc z/tag))
+       (= 'state-flow.cljtest (-> zloc z/down z/sexpr))))
+
+(defn refactor-require** [zloc]
+  (z/edit-> zloc
+            z/down
+            (z/replace (z/node (z/of-string "state-flow.assertions.matcher-combinators")))))
+
+(defn refactor-require* [zloc]
+  (loop [zloc zloc]
+    (let [updated (try
+                    (z/postwalk zloc old-require? refactor-require**)
+                    (catch Exception _ zloc))]
+      (if (z/rightmost? updated)
+        updated
+        (recur (z/right updated))))))
+
+(defn refactor-require
+  "Given a map with :path to a file or a string :str, returns
+  a string with all of the match? expressions refactored as follows:
+
+  Given an ns declaration with this in require:
+
+    [state-flow.cljtest :refer [match?]]
+
+  Refactor it to
+
+    [state-flow.assertions.matcher-combinators :refer [match?]]"
+  [{:keys [path
+           str
+           rewrite]}]
+  (let [z-before (or (and path (z/of-file path))
+                     (and str (z/of-string str)))
+        z-after  (z/root-string (refactor-require* z-before))]
     (if (and path rewrite)
       (spit (io/file path) z-after)
       z-after)))
 
 (comment
-  (refactor-all {:path "test/state_flow/cljtest_test.clj"
-                 :sym-before 'cljtest/match?
-                 :sym-after 'assertions.matcher-combinators/match?
-                 :wrap-in-flow true
-                 :rewrite true}))
+  (refactor-match-exprs {:path "test/state_flow/cljtest_test.clj"
+                         :sym-before 'cljtest/match?
+                         :sym-after 'assertions.matcher-combinators/match?
+                         :wrap-in-flow true
+                         :rewrite true}))

--- a/src/state_flow/refactoring_tools/refactor_match.clj
+++ b/src/state_flow/refactoring_tools/refactor_match.clj
@@ -119,16 +119,20 @@
   WARNING: the old version of match? probes implicitly when `actual` is a step. The new
   version requires an explicit `{:times-to-try <value gt 1>}` to trigger polling, so
   leaving out :force-probe-params may result in tests failing because they need probe."
-  [{:keys [path str
+  [{:keys [path
+           str
            sym-before
            sym-after
            rewrite
            wrap-in-flow
            force-probe-params]
-    :as opts}]
-  (let [z-before (or (and path (z/of-file path))
+    :as   opts}]
+  (let [opts*    (merge {:sym-before 'match?
+                         :sym-after  'match?}
+                        opts)
+        z-before (or (and path (z/of-file path))
                      (and str (z/of-string str)))
-        z-after  (z/root-string (refactor-all* opts z-before))]
+        z-after  (z/root-string (refactor-all* opts* z-before))]
     (if (and path rewrite)
       (spit (io/file path) z-after)
       z-after)))

--- a/test/state_flow/refactoring_tools/refactor_match_test.clj
+++ b/test/state_flow/refactoring_tools/refactor_match_test.clj
@@ -54,32 +54,40 @@
               :sym-after          'after/match?}
              (zip '(before/match? "description" actual expected {:sleep-time 250}))))))))
 
-(deftest refactor-all
+(deftest refactor-match-exprs
   (testing "at root"
     (is (= "(after/match? expected actual)"
-           (refactor-match/refactor-all
+           (refactor-match/refactor-match-exprs
             {:str "(before/match? \"description\" actual expected)"
              :sym-before 'before/match?
              :sym-after 'after/match?}))))
 
   (testing "in deftest"
     (is (= "(deftest thing (after/match? expected actual))"
-           (refactor-match/refactor-all
+           (refactor-match/refactor-match-exprs
             {:str "(deftest thing (before/match? \"description\" actual expected))"
              :sym-before 'before/match?
              :sym-after 'after/match?}))))
 
   (testing "multiple matches"
     (is (= "(deftest thing (after/match? expected actual)\n  (after/match? expected2 actual2))"
-           (refactor-match/refactor-all
+           (refactor-match/refactor-match-exprs
             {:str "(deftest thing (before/match? \"description\" actual expected)\n  (before/match? \"description\" actual2 expected2))"
              :sym-before 'before/match?
              :sym-after 'after/match?}))))
 
   (testing "with wrap-in-flow option"
-    (is (= "(deftest thing (flow \"description\" (after/match? expected actual)))"
-           (refactor-match/refactor-all
+    (is (= "(deftest thing (flow \"description\" \n(after/match? expected actual)))"
+           (refactor-match/refactor-match-exprs
             {:str "(deftest thing (before/match? \"description\" actual expected))"
              :sym-before 'before/match?
              :sym-after 'after/match?
              :wrap-in-flow true})))))
+
+(deftest refactor-require
+  (is (= "(ns x\n (:require [state-flow.assertions.matcher-combinators]))"
+         (refactor-match/refactor-require {:str "(ns x\n (:require [state-flow.cljtest]))"})))
+  (is (= "(ns x\n (:require [state-flow.assertions.matcher-combinators]))"
+         (refactor-match/refactor-require {:str "(ns x\n (:require [state-flow.cljtest]))"})))
+  (is (= "(ns x\n (:require [state-flow.assertions.matcher-combinators :refer [match?]]))"
+         (refactor-match/refactor-require {:str "(ns x\n (:require [state-flow.cljtest :refer [match?]]))"}))))

--- a/test/state_flow/refactoring_tools/refactor_match_test.clj
+++ b/test/state_flow/refactoring_tools/refactor_match_test.clj
@@ -85,9 +85,9 @@
              :wrap-in-flow true})))))
 
 (deftest refactor-require
-  (is (= "(ns x\n (:require [state-flow.assertions.matcher-combinators]))"
-         (refactor-match/refactor-require {:str "(ns x\n (:require [state-flow.cljtest]))"})))
-  (is (= "(ns x\n (:require [state-flow.assertions.matcher-combinators]))"
+  (is (= "(ns x\n (:require [state-flow.cljtest]))"
          (refactor-match/refactor-require {:str "(ns x\n (:require [state-flow.cljtest]))"})))
   (is (= "(ns x\n (:require [state-flow.assertions.matcher-combinators :refer [match?]]))"
-         (refactor-match/refactor-require {:str "(ns x\n (:require [state-flow.cljtest :refer [match?]]))"}))))
+         (refactor-match/refactor-require {:str "(ns x\n (:require [state-flow.cljtest :refer [match?]]))"})))
+  (is (= "(ns x\n (:require [state-flow.assertions.matcher-combinators :refer [match?]] \n [state-flow.cljtest :refer [defflow]]))"
+         (refactor-match/refactor-require {:str "(ns x\n (:require [state-flow.cljtest :refer [defflow match?]]))"}))))

--- a/test/state_flow/refactoring_tools/refactor_match_test.clj
+++ b/test/state_flow/refactoring_tools/refactor_match_test.clj
@@ -85,9 +85,19 @@
              :wrap-in-flow true})))))
 
 (deftest refactor-require
-  (is (= "(ns x\n (:require [state-flow.cljtest]))"
-         (refactor-match/refactor-require {:str "(ns x\n (:require [state-flow.cljtest]))"})))
-  (is (= "(ns x\n (:require [state-flow.assertions.matcher-combinators :refer [match?]]))"
-         (refactor-match/refactor-require {:str "(ns x\n (:require [state-flow.cljtest :refer [match?]]))"})))
-  (is (= "(ns x\n (:require [state-flow.assertions.matcher-combinators :refer [match?]] \n [state-flow.cljtest :refer [defflow]]))"
-         (refactor-match/refactor-require {:str "(ns x\n (:require [state-flow.cljtest :refer [defflow match?]]))"}))))
+  (testing "ns declarations that get refactored"
+    (is (= "(ns x\n (:require [state-flow.assertions.matcher-combinators :refer [match?]]))"
+           (refactor-match/refactor-require {:str "(ns x\n (:require [state-flow.cljtest :refer [match?]]))"})))
+    (is (= "(ns x\n (:require [state-flow.assertions.matcher-combinators :refer [match?]] \n [state-flow.cljtest :refer [defflow]]))"
+           (refactor-match/refactor-require {:str "(ns x\n (:require [state-flow.cljtest :refer [defflow match?]]))"})))
+    (is (= "(ns x\n (some-expression)\n (:require [state-flow.assertions.matcher-combinators :refer [match?]]))"
+           (refactor-match/refactor-require {:str "(ns x\n (some-expression)\n (:require [state-flow.cljtest :refer [match?]]))"})))
+    (is (= "(ns x\n (some-expression)\n (:require [clojure.string :as str]\n [state-flow.assertions.matcher-combinators :refer [match?]]))"
+           (refactor-match/refactor-require {:str "(ns x\n (some-expression)\n (:require [clojure.string :as str]\n [state-flow.cljtest :refer [match?]]))"}))))
+  (testing "ns declarations that don't change"
+    (doseq [exp ["(ns x\n (:require [state-flow.cljtest]))"
+                 "(ns x\n (:require [state-flow.cljtest :refer [defflow]]))"
+                 "(ns x\n (:require [another-library :refer [match?]]))"
+                 "(ns x\n (some-expression)\n (:require [another.lib :refer [match?]]))"
+                 "(ns x\n (some-expression)\n (:require [clojure.string :as str]\n [another.lib :refer [match?]]))"]]
+      (is (= exp (refactor-match/refactor-require {:str exp}))))))

--- a/test/state_flow/state_test.clj
+++ b/test/state_flow/state_test.clj
@@ -21,7 +21,7 @@
                                          (state/modify (fn [s] (throw (Exception. "My exception"))))
                                          double-state) 2)]
         (is (e/failure? res))
-        (is (= 8 state)))))
+        (is (= 8 state))))))
 
 (deftest get-and-put
   (let [increment-state (m/mlet [x (state/get)


### PR DESCRIPTION
* add shell script to refactor match?
  * `bin/refactor-match? --help` for instruction
  * refactors match expressions and (some) ns declarations
* fix propagation of defaults
* insert newline when wrapping in flow, e.g.

```clojure
(match? "desc" actual expected)
;; becomes
(flow "desc"
(match? expected actual))
;; then it's up to you to reformat with e.g. `lein cljfmt fix`
```

* refactor `:require` expressions as well, e.g.

```clojure
(ns a-namespace
  (:require [state-flow.cljtest :refer [match?]]))
;; becomes
(ns a-namespace
  (:require [state-flow.assertions.matcher-combinators :refer [match?]]))
```
```clojure
(ns a-namespace
  (:require [state-flow.cljtest :refer [defflow match?]]))
;; becomes
(ns a-namespace
  (:require [state-flow.assertions.matcher-combinators :refer [match?]]
            [state-flow.cljtest :refer [defflow]]))
```