### PR TITLE
Fix exception on fmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.2.6]
+
+- Fix issues with exceptions being thrown and not returned as the left value of
+  the error-state monad
+
 ## [2.2.5]
 
 - add shell script to refactor match? expressions and `:require [state-flow.cljtest} ...`

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "2.2.5"
+(defproject nubank/state-flow "2.2.6"
   :description "Postman-like integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}

--- a/src/state_flow/state.clj
+++ b/src/state_flow/state.clj
@@ -9,7 +9,7 @@
 
 (declare error-context)
 
-(defn- result-or-err [f args]
+(defn- result-or-err [f & args]
   (let [result ((e/wrap (partial apply f)) args)]
     (if (e/failure? result)
       result
@@ -49,7 +49,7 @@
 
     p/Monad
     (-mreturn [_ v]
-      (error-state (partial vector v)))
+      (error-state #(vector v %)))
 
     (-mbind [_ self f]
       (error-state

--- a/src/state_flow/state.clj
+++ b/src/state_flow/state.clj
@@ -112,7 +112,8 @@
                  [(my-fn) s])
                error-context))
 
-(def state? state/state?)
+(defn state? [v]
+  (instance? ErrorState v))
 (def run state/run)
 (def eval state/eval)
 (def exec state/exec)

--- a/src/state_flow/state.clj
+++ b/src/state_flow/state.clj
@@ -15,18 +15,17 @@
       result
       @result)))
 
-(defn- result-or-err-pair [f s]
-  (let [new-pair ((e/wrap f) s)]
-    (if (e/failure? new-pair)
-      [new-pair s]
-      @new-pair)))
-
 (defrecord ErrorState [mfn]
   p/Contextual
   (-get-context [_] error-context)
 
   p/Extract
-  (-extract [_] (partial result-or-err-pair mfn)))
+  (-extract [_]
+    (fn [s]
+      (let [new-pair ((e/wrap mfn) s)]
+        (if (e/failure? new-pair)
+          [new-pair s]
+          @new-pair)))))
 
 (alter-meta! #'->ErrorState assoc :private true)
 (alter-meta! #'map->ErrorState assoc :private true)

--- a/src/state_flow/state.clj
+++ b/src/state_flow/state.clj
@@ -21,8 +21,17 @@
     p/Functor
     (-fmap [_ f fv]
       (state/state (fn [s]
-                     (let [[v ns]  ((p/-extract fv) s)]
-                       [(f v) ns]))
+                     (let [mp ((e/wrap (p/-extract fv)) s)]
+                       (cond
+                         (e/failure? mp)
+                         (d/pair mp s)
+
+                         (e/failure? (first @mp))
+                         @mp
+
+                         :default
+                         (let [[v ns] @mp]
+                           [(f v) ns]))))
                    error-context))
 
     p/Monad

--- a/src/state_flow/state.clj
+++ b/src/state_flow/state.clj
@@ -108,12 +108,9 @@
 (defn wrap-fn
   "Wraps a (possibly side-effecting) function to a state monad"
   [my-fn]
-  (state/state (fn [s]
-                 [(my-fn) s])
-               error-context))
+  (error-state (fn [s] [(my-fn) s])))
 
-(defn state? [v]
-  (instance? ErrorState v))
+(defn state? [v] (instance? ErrorState v))
 (def run state/run)
 (def eval state/eval)
 (def exec state/exec)

--- a/src/state_flow/state.clj
+++ b/src/state_flow/state.clj
@@ -2,7 +2,6 @@
   (:refer-clojure :exclude [eval get])
   (:require [cats.context :as ctx :refer [*context*]]
             [cats.core :as m]
-            [cats.data :as d]
             [cats.monad.exception :as e]
             [cats.monad.state :as state]
             [cats.protocols :as p]
@@ -24,7 +23,7 @@
                      (let [mp ((e/wrap (p/-extract fv)) s)]
                        (cond
                          (e/failure? mp)
-                         (d/pair mp s)
+                         [mp s]
 
                          (e/failure? (first @mp))
                          @mp

--- a/test/state_flow/state_test.clj
+++ b/test/state_flow/state_test.clj
@@ -21,7 +21,16 @@
                                          (state/modify (fn [s] (throw (Exception. "My exception"))))
                                          double-state) 2)]
         (is (e/failure? res))
-        (is (= 8 state))))))
+        (is (= 8 state))))
+
+    (testing "also handles exceptions with fmap"
+      (let [[res state] (state/run
+                          (m/fmap inc (m/>> double-state
+                                            double-state
+                                            (state/modify (fn [s] (throw (Exception. "My exception"))))
+                                            double-state)) 2)]
+           (is (e/failure? res))
+           (is (= 8 state))))))
 
 (deftest get-and-put
   (let [increment-state (m/mlet [x (state/get)

--- a/test/state_flow/state_test.clj
+++ b/test/state_flow/state_test.clj
@@ -10,7 +10,14 @@
     (is (state/gets inc))
     (is (state/modify inc))
     (is (state/return 37))
-    (is (state/put {:count 0}))))
+    (is (state/put {:count 0})))
+
+  (testing "primitives returns correct values"
+    (is (= [2 2] (state/run (state/get) 2)))
+    (is (= [3 2] (state/run (state/gets inc) 2)))
+    (is (= [2 3] (state/run (state/modify inc) 2)))
+    (is (= [37 2] (state/run (state/return 37) 2)))
+    (is (= [2 3] (state/run (state/put 3) 2)))))
 
 (deftest exception-handling
   (let [double-state (state/modify * 2)]

--- a/test/state_flow/state_test.clj
+++ b/test/state_flow/state_test.clj
@@ -10,14 +10,24 @@
     (is (state/gets inc))
     (is (state/modify inc))
     (is (state/return 37))
-    (is (state/put {:count 0})))
+    (is (state/put {:count 0}))
+    (is (state/wrap-fn inc)))
 
   (testing "primitives returns correct values"
     (is (= [2 2] (state/run (state/get) 2)))
     (is (= [3 2] (state/run (state/gets inc) 2)))
     (is (= [2 3] (state/run (state/modify inc) 2)))
     (is (= [37 2] (state/run (state/return 37) 2)))
-    (is (= [2 3] (state/run (state/put 3) 2)))))
+    (is (= [2 3] (state/run (state/put 3) 2)))
+    (is (= ["hello" 2] (state/run (state/wrap-fn (constantly "hello")) 2))))
+
+  (testing "all primitives are states"
+    (is (state/state? (state/get)))
+    (is (state/state? (state/gets inc)))
+    (is (state/state? (state/modify inc)))
+    (is (state/state? (state/return 37)))
+    (is (state/state? (state/put {:count 0})))
+    (is (state/state? (state/wrap-fn (constantly "hello"))))))
 
 (deftest exception-handling
   (let [double-state (state/modify * 2)]

--- a/test/state_flow/state_test.clj
+++ b/test/state_flow/state_test.clj
@@ -5,14 +5,6 @@
             [state-flow.state :as state]))
 
 (deftest primitives
-  (testing "primitives are constructable outside monad context"
-    (is (state/get))
-    (is (state/gets inc))
-    (is (state/modify inc))
-    (is (state/return 37))
-    (is (state/put {:count 0}))
-    (is (state/wrap-fn inc)))
-
   (testing "primitives returns correct values"
     (is (= [2 2] (state/run (state/get) 2)))
     (is (= [3 2] (state/run (state/gets inc) 2)))

--- a/test/state_flow/state_test.clj
+++ b/test/state_flow/state_test.clj
@@ -1,8 +1,7 @@
 (ns state-flow.state-test
-  (:require [clojure.test :as t :refer [deftest testing is]]
-            [cats.core :as m]
-            [cats.data :as d]
+  (:require [cats.core :as m]
             [cats.monad.exception :as e]
+            [clojure.test :as t :refer [deftest is testing]]
             [state-flow.state :as state]))
 
 (deftest primitives
@@ -30,7 +29,27 @@
                                             (state/modify (fn [s] (throw (Exception. "My exception"))))
                                             double-state)) 2)]
            (is (e/failure? res))
-           (is (= 8 state))))))
+           (is (= 8 state)))
+
+      (let [[res state] (state/run
+                          (m/>> double-state
+                                double-state
+                                (state/modify (fn [s] (throw (Exception. "My exception"))))
+                                double-state) 2)]
+        (is (e/failure? res))
+        (is (= 8 state)))
+
+      (let [[res state] (state/run
+                          (m/>> (m/fmap (fn [s] (throw (Exception. "My exception")))
+                                        (m/>> double-state
+                                              double-state))
+                                double-state) 2)]
+           (is (e/failure? res))
+           (is (= 8 state)))))
+
+  (testing "exceptions in primitives are returned as the result"
+    (is (e/failure? (first (state/run (state/gets #(/ 2 %)) 0))))
+    (is (e/failure? (first (state/run (state/modify #(/ 2 %)) 0))))))
 
 (deftest get-and-put
   (let [increment-state (m/mlet [x (state/get)

--- a/test/state_flow/state_test.clj
+++ b/test/state_flow/state_test.clj
@@ -37,8 +37,8 @@
                                             double-state
                                             (state/modify (fn [s] (throw (Exception. "My exception"))))
                                             double-state)) 2)]
-           (is (e/failure? res))
-           (is (= 8 state)))
+        (is (e/failure? res))
+        (is (= 8 state)))
 
       (let [[res state] (state/run
                           (m/>> double-state
@@ -53,8 +53,8 @@
                                         (m/>> double-state
                                               double-state))
                                 double-state) 2)]
-           (is (e/failure? res))
-           (is (= 8 state)))))
+        (is (e/failure? res))
+        (is (= 8 state)))))
 
   (testing "exceptions in primitives are returned as the result"
     (is (e/failure? (first (state/run (state/gets #(/ 2 %)) 0))))


### PR DESCRIPTION
Previously the added testcase would __throw__:

```clojure
java.lang.ClassCastException: cats.monad.exception.Failure cannot be cast to java.lang.Number
```