### PR TITLE
Cleanup namespaces

### DIFF
--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -1,13 +1,12 @@
 (ns state-flow.core
   (:refer-clojure :exclude [run!])
-  (:require [clojure.string :as str]
-            [cats.core :as m]
+  (:require [cats.core :as m]
             [cats.data :as d]
             [cats.monad.exception :as e]
+            [clojure.pprint :as pp]
+            [clojure.string :as str]
             [state-flow.state :as state]
-            [taoensso.timbre :as log]
-            [clojure.pprint :as pp])
-  (:import java.lang.Throwable))
+            [taoensso.timbre :as log]))
 
 ;; From time to time we see the following error when trying to pretty-print
 ;; Failure records:
@@ -41,10 +40,11 @@
                                                               (when line
                                                                 (format " (line %s)" line))))))))
 
-(defn pop-meta []
+(defn pop-meta
   "Returns a flow that will modify the state metadata.
 
   For internal use. Subject to change."
+  []
   (modify-meta update :description-stack pop))
 
 (defn ^:private format-description

--- a/src/state_flow/labs/cljtest.clj
+++ b/src/state_flow/labs/cljtest.clj
@@ -3,8 +3,9 @@
             [state-flow.state :as state]
             [clojure.test :as ctest]))
 
-(defmacro testing [desc & body]
+(defmacro testing
   "state-flow's equivalent to clojure test's `testing`"
+  [desc & body]
   `(core/flow ~desc
      [full-desc# (core/current-description)]
      (state/wrap-fn #(do ~(with-meta `(ctest/testing ~desc ~@body)

--- a/src/state_flow/state.clj
+++ b/src/state_flow/state.clj
@@ -1,7 +1,6 @@
 (ns state-flow.state
   (:refer-clojure :exclude [eval get])
-  (:require [cats.context :as ctx :refer [*context*]]
-            [cats.core :as m]
+  (:require [cats.core :as m]
             [cats.monad.exception :as e]
             [cats.monad.state :as state]
             [cats.protocols :as p]
@@ -30,7 +29,7 @@
     p/Context
 
     p/Functor
-    (-fmap [self f fv]
+    (-fmap [_ f fv]
       (error-state
        (fn [s]
          (let [[v s'] ((p/-extract fv) s)]
@@ -72,8 +71,8 @@
   (state/get error-context))
 
 (defn gets
-  [f & args]
   "Returns the equivalent of (fn [state] [state, (apply f state args)])"
+  [f & args]
   (state/gets #(apply f % args) error-context))
 
 (defn put


### PR DESCRIPTION
## Context

Gets rid of some warnings by fixing some misplaced docstrings and removing unused namespaces