### PR TITLE
Throw when times-to-try > 1 and actual is a value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [DEV]
+
+* Throw when calling match? with times-to-try > 1 and a value for actual (should be a step) [#116](https://github.com/nubank/state-flow/pull/116)
+
 ## [3.0.0]
 
 *WARNING*: for any code relying on previously undocumented behavior of

--- a/test/state_flow/assertions/matcher_combinators_test.clj
+++ b/test/state_flow/assertions/matcher_combinators_test.clj
@@ -7,7 +7,8 @@
             [state-flow.assertions.matcher-combinators :as mc]
             [state-flow.test-helpers :as test-helpers :refer [shhh!]]
             [state-flow.state :as state]
-            [state-flow.core :as state-flow :refer [flow]]))
+            [state-flow.core :as state-flow :refer [flow]]
+            [taoensso.timbre :as log]))
 
 (def get-value-state (state/gets (comp deref :value)))
 
@@ -103,3 +104,8 @@
          (first (shhh! (state/run
                          (m/fmap mc/report->actual (mc/match? :expected :actual))
                          {}))))))
+
+(deftest test-match?-with-probe
+  (testing "warns when (> 1 times-to-try) and actual is a value instead of a step"
+    (is (match? #"WARN.*has no meaningful effect"
+                (with-out-str (state/run (mc/match? 3 3 {:times-to-try 2}) {}))))))


### PR DESCRIPTION
Users have reported failures when probing where it turned out that `match?` was given a value instead of a step to produce the value, e.g.

```clojure
[res (do-a-step)]
(match? 37 res {:times-to-try 2})
```

This PR adds a warning when :times-to-try is > 1 and `actual` is a value instead of a step.