### PR TITLE
add state-flow.api namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [4.0.0]
+
+* Add `state-flow.api` namespace [#118](https://github.com/nubank/state-flow/pull/118)
+  * New namespace which has everything you need™
+  * New `fmap` fn
+
 ## [3.1.0]
 
 * Add state-flow.core/runner to access runner within flows [#119](https://github.com/nubank/state-flow/pull/119)

--- a/doc/walkthrough.repl
+++ b/doc/walkthrough.repl
@@ -1,13 +1,10 @@
-(require '[state-flow.core :refer [flow run run*]]
-         '[state-flow.state :as state]
-         '[matcher-combinators.core]
-         '[state-flow.assertions.matcher-combinators :refer [match?]])
+(require '[state-flow.api :as flow :refer [run run* flow match?]])
 
-;; An integration test flow, as we see it, is a series of steps with
+;; An integration test can be expressed as a series of steps with
 ;; assertions mixed in. Ideally, all of the steps are pure functions,
 ;; meaning they don't access any external state. To support that, we
-;; need to thread the state through the functions. One way we can do
-;; this in Clojure is with the -> macro:
+;; need to thread the state through the functions. We _could_ use Clojure's
+;; -> macro to do this:
 
 (-> {:count 0} ;; << state - we'll refer to it as s in the next steps
     ((fn [s] (update s :count inc)))
@@ -37,14 +34,14 @@
 
 (run                                 ;; << `run` takes a flow and an initial state
   (flow "increment count"            ;; << a `flow` is a collection of steps
-    (state/modify update :count inc) ;; << step that updates state, incrementing :count
-    (match? 1 (state/gets :count))   ;; << step that asserts the :count is 1
-    (state/get))                     ;; << step that returns the state
+    (flow/swap-state update :count inc) ;; << step that updates state, incrementing :count
+    (match? 1 (flow/get-state :count))   ;; << step that asserts the :count is 1
+    (flow/get-state))                     ;; << step that returns the state
   {:count 0})                        ;; << initial state
 ;; => [{:count 1} {:count 1}]        ;; << result pair - we'll explain this later
 ;;
 ;; Note that we said "step that updates state". But we just said
-;; that these functions should be pure! Well, actually the `state/modify`
+;; that these functions should be pure! Well, actually the `flow/swap-state`
 ;; function itself just returns the result of applying `update`, in
 ;; this example, to whatever is passed to it, e.g.
 
@@ -76,12 +73,13 @@
 ;; number of constructors for primitive steps (state monads).
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; state/get
+;; flow/get-state
 ;;
-;; `state/get` is a primitive step whose <left-value> is the state.
+;; flow/get-state is a primitive step that returns the application of a
+;; function to the state, leaving the state intact.
 
 ;; First, let's just see what it evaluates to by itself.
-(state/get)
+(flow/get-state :count)
 ;; => {:mfn #function[...],
 ;;     :state-context #<State-E>}
 
@@ -102,155 +100,128 @@
 ;; Since this is just a Clojure function, you can extract it from the
 ;; step (monad) and invoke it directly:
 
-(let [f (:mfn (state/get))]
+(let [f (:mfn (flow/get-state :count))]
   (f {:count 0}))
-;; => [{:count 0} {:count 0}]
-;;
-;; The `{count 0}` on the left, the <left-value> or <return-value>, is
-;; the state before invoking `state/get`.  Since we passed `{count 0}`
-;; to `f`, that is what `state/get` returns.
-;;
-;; The `{count 0}` on the right, the <right-value> or <state>, is the
-;; state _after_ invoking `state/get`.  Since `state/get` does not
-;; modify the state, it's the same value we handed to `f`.
+;; => [0 {:count 0}]
 ;;
 ;; state-flow provides a `run` function that binds the state to the
 ;; function argument for you:
 
-(run (state/get) {:count 0})
-;; => [{:count 0} {:count 0}]
+(run (flow/get-state :count) {:count 0})
+;; => [0 {:count 0}]
 ;;
 ;; The `run` function takes a step and an (optional - defaults to an
 ;; empty {}) initial state, and returns the return value from invoking
 ;; the :mfn with the state. Here's the same example with the default
 ;; initial-state:
 
-(run (state/get))
+(run (flow/get-state identity))
 ;; => [{} {}]
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; state/gets
-;;
-;; state/gets is a primitive step that returns the application of a
-;; function to the state, leaving the state intact.
 
-(run (state/gets (fn [s] (update s :count inc))) {:count 0})
+(run (flow/get-state (fn [s] (update s :count inc))) {:count 0})
 ;;      return     state
 ;; => [{:count 1} {:count 0}]
 ;;
 ;; The `{count 1}` on the left, the <left-value> or <return-value>, is
-;; the result of applying the function we passed to `state/gets` to
+;; the result of applying the function we passed to `flow/get-state` to
 ;; the state.  Since we passed `{count 0}` to `f`, that is passed to
 ;; `(fn [s] (update s :count + 1))`, which returns `{count 1}`.
 ;;
 ;; The `{count 0}` on the right, the <right-value> or <state>, is the
-;; state _after_ invoking `state/gets`.  Since `state/gets` does not
+;; state _after_ invoking `flow/get-state`.  Since `flow/get-state` does not
 ;; modify the state, it's the same value we handed to `f`.
 ;;
-;; `state/gets` also supports compositional function chaining by
+;; `flow/get-state` also supports compositional function chaining by
 ;; passing additional args to the function, like e.g. Clojure's
 ;; `update` function
 
-(run (state/gets update :count inc) {:count 0})
+(run (flow/get-state update :count inc) {:count 0})
 ;; => [{:count 1} {:count 0}]
 
-(run (state/gets update :count + 2) {:count 0})
+(run (flow/get-state update :count + 2) {:count 0})
 ;; => [{:count 2} {:count 0}]
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; state/modify
+;; flow/swap-state
 ;;
-;; `state/modify` does the reverse of `state/gets`: it returns the
-;; unmodified state and applies a function to the state:
+;; `flow/swap-state` is the complement of `flow/get-state`: it returns
+;; the unmodified state and applies a function to the state:
 
-(run (state/modify (fn [s] (update s :count inc))) {:count 0})
+(run (flow/swap-state (fn [s] (update s :count inc))) {:count 0})
 ;; => [{:count 0} {:count 1}]
 ;;
 ;; The `{count 0}` on the left, the <left-value> or <return-value>, is
-;; the value of the state before `state/modify`.
+;; the value of the state before `flow/swap-state`.
 ;;
 ;; The `{count 1}` on the right, the <right-value> or <state>, is the
-;; the result of applying the function we passed to `state/modify` to
+;; the result of applying the function we passed to `flow/swap-state` to
 ;; the state.  Since we passed `{count 0}` to `f`, that is passed to
 ;; `(fn [s] (update s :count + 1))`, which leaves the state `{count 1}`.
 ;;
-;; And `state/modify` also passes additional args to the function;
+;; And `flow/swap-state` also passes additional args to the function;
 
-(run (state/modify update :count inc) {:count 0})
+(run (flow/swap-state update :count inc) {:count 0})
 ;; => [{:count 0} {:count 1}]
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; state/return
+;; flow/return
 ;;
-;; `state/return` returns the value given to it, leaving state unchanged
+;; `flow/return` returns the value given to it, leaving state unchanged
 
-(run (state/return {:a 37}) {:b 42})
+(run (flow/return {:a 37}) {:b 42})
 ;; => [{:a 37} {:b 42}]
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; state/put
-;;
-;; `state/put` replaces the state entirely, returning the state
-;; as it was before the step.
-
-(run (state/put {:name "Jacob"}) {:count 0})
-;; => [{:count 0} {:name "Jacob"}]
+;; `flow/return` is most useful as the last step of a flow, to clearly
+;; indicate what the flow will return when used within another flow.
 
 ;; ------------------------------------------------
 ;; flows
 ;; ------------------------------------------------
 ;;
-;; We use flows to string together several steps in a single step:
+;; We use flows to compose steps
 
-(flow "counter"
-  (state/modify update :count inc)
-  (state/modify update :count inc)
-  (state/modify update :count inc))
+(flow "c -> f"
+  (flow/swap-state (fn [s] (assoc s :f (:c s))))
+  (flow/swap-state update :f * 9)
+  (flow/swap-state update :f / 5)
+  (flow/swap-state update :f + 32)
+  (flow/get-state :f))
 ;; => {:mfn #object[...],
 ;;     :state-context #<State-E>}
 ;;
 ;; And, then we can hand that directly to the run function, which
 ;; returns the result of the last step
 
-(run (flow "counter"
-       (state/modify update :count inc)
-       (state/modify update :count inc)
-       (state/modify update :count inc))
-  {:count 0})
-;; => [{:count 2} {:count 3}]
+(run (flow "c -> f"
+       (flow/swap-state (fn [s] (assoc s :f (:c s))))
+       (flow/swap-state update :f * 9)
+       (flow/swap-state update :f / 5)
+       (flow/swap-state update :f + 32)
+       (flow/get-state :f))
+  {:c 0})
+;; => [32 {:c 0, :f 32}]
 
-(run (flow "counter"
-       (state/gets update :count inc)
-       (state/gets update :count inc)
-       (state/gets update :count inc))
-  {:count 0})
-;; => [{:count 1} {:count 0}]
+;; We can compose groups of steps
 
-;; Since steps are values, we can def them
-(def inc-count (state/modify update :count inc))
+(defn c->f [k]
+  (flow "c -> f"
+    (flow/swap-state update k * 9)
+    (flow/swap-state update k / 5)
+    (flow/swap-state update k + 32)
+    (flow/get-state k)))
 
-(run inc-count {:count 0})
-;; => [{:count 0} {:count 1}]
+(defn copy-key [source target]
+  (flow/swap-state (fn [s] (assoc s target (get s source)))))
 
-;; Same with flows
-(def inc-twice (flow "increment twice"
-                 inc-count
-                 inc-count))
+;; ... and then compose the compositions;
 
-(run inc-twice {:count 0})
-;; => [{:count 1} {:count 2}]
-
-;; And we can nest flows arbitrarily deeply!
-(run
-  (flow "inc (parent)"
-    inc-count
-    (flow "inc twice (child)"
-      inc-twice
-      (flow "inc 2 more times (grandchild)"
-        inc-twice))
-    (state/gets update :count * 3))
-  {:count 0})
-;; => [{:count 15} {:count 5}]
+(run (flow "0c to f"
+       (copy-key :c :f)
+       (c->f :f)
+       (flow/get-state :f))
+  {:c 0})
+;; => [32 {:c 0, :f 32}]
 
 ;; ------------------------------------------------
 ;; bindings
@@ -261,13 +232,13 @@
 
 (run
   (flow "binding example"
-    [count-before (state/gets :count)] ;; <- step produces [0 {:count 0}], binding binds 0 to `count-before`
-    (state/modify update :count inc)   ;; <- increments the value :count within the state
-    [count-after (state/gets :count)]  ;; <- step produces [1 {:count 1}], binding binds 1 to `count-after`
-    (state/return {:before count-before
-                   :after  count-after}))
-  {:count 0})
-;; => [{:before 0, :after 1} {:count 1}]
+    [c (flow/get-state :c)]
+    (copy-key :c :f)
+    (c->f :f)
+    [f (flow/get-state :f)]
+    (flow/return [c f]))
+  {:c 0})
+;; => [[0 32] {:c 0 :f 32}]
 
 ;; These look a lot like `let` bindings, but the symbol on the left
 ;; will be bound to the return of the monad on the right. You can also
@@ -275,23 +246,13 @@
 
 (run
   (flow "binding example"
-    [:let [value-to-add-to-count 37]] ;; <- binds 37 to `value-to-add-to-count`
-    ;; same as [value-to-add-to-count (state/return 37)]
-    (state/modify update :count + value-to-add-to-count)
-    (state/gets :count))
-  {:count 0})
-;; => [37 {:count 37}]
-
-;; And those values can come from evaluating regular Clojure expressions:
-
-(run
-  (flow "binding example"
-    [:let [value-to-add-to-count (+ 30 7)]]
-    ;; same as [value-to-add-to-count (state/return (+ 30 7))]
-    (state/modify update :count + value-to-add-to-count)
-    (state/gets :count))
-  {:count 0})
-;; => [37 {:count 37}]
+    [:let [c 0]]
+    (flow/swap-state assoc :c 0)
+    (copy-key :c :f)
+    (c->f :f)
+    [f (flow/get-state :f)]
+    (flow/return [c f])))
+;; => [[0 32] {:c 0 :f 32}]
 
 ;; ------------------------------------------------
 ;; beyond primitives
@@ -300,19 +261,7 @@
 ;; So far we've only dealt with functions that interact directly with
 ;; state. In practice, we want to execute functions that are specific
 ;; to our domain, that don't interact directly with the flow state
-;; To run a normal clojure expression in a flow, you can wrap it
-;; in a function and pass it to `wrap-fn`:
-
-(run (state/wrap-fn #(+ 1 2)) {})
-;; => [3 {}]
-
-(run
-  (flow "get three"
-    [result (state/wrap-fn #(+ 1 2))]
-    (state/return result))
-  {})
-;; [3 {}]
-
+;;
 ;; Here's a more practical example, in which we draw from state
 ;; to provide arguments to domain functions.
 
@@ -326,11 +275,11 @@
 
 (defn register-user-helper [user]
   (flow "register user"
-    (state/gets (fn [{:keys [db]}] (register-user db user)))))
+    (flow/get-state (fn [{:keys [db]}] (register-user db user)))))
 
 (defn fetch-users-helper []
   (flow "fetch users"
-    (state/gets (fn [{:keys [db]}] (fetch-users db)))))
+    (flow/get-state (fn [{:keys [db]}] (fetch-users db)))))
 
 ;; flow
 
@@ -402,17 +351,17 @@
 (run
   (flow "fails"
     (match? 2 1)
-    (state/wrap-fn #(throw (ex-info "boom!" {})))
+    (flow/invoke #(throw (ex-info "boom!" {})))
     (flow "is never run"
       (match? 4 3)))
   {})
 
 ;; `run*` raises the exception by default
-(state-flow.core/run*
+(run*
   {:init (constantly {})}
   (flow "fails"
     (match? 2 1)
-    (state/wrap-fn #(throw (ex-info "boom!" {})))
+    (flow/invoke #(throw (ex-info "boom!" {})))
     (flow "is never run"
       (match? 4 3))))
 
@@ -420,7 +369,7 @@
 ;; clojure.test integration: defflow
 ;; ------------------------------------------------
 
-(require '[state-flow.cljtest :refer [defflow]])
+(require '[state-flow.api :refer [defflow]])
 
 ;; defflow produces a function, like clojure.test's deftest, which
 ;; can be invoked directly, or through clojure.test's run functions
@@ -438,7 +387,7 @@
 ;;     :name store-and-retrieve-users,
 ;;     :ns #namespace[user]}
 
-(clojure.test/test-var #'store-and-retrieve-users)
+(clojure.test/test-vars [#'store-and-retrieve-users])
 
 ;; Common practice is to include a project-specific version of
 ;; defflow, which wraps defflow and passes it a common :init,
@@ -455,6 +404,6 @@
    (match? #{{:name "Philip"}}
            (fetch-users-helper))))
 
-  (meta #'store-and-retrieve-users-again)
+(meta #'store-and-retrieve-users-again)
 
-(clojure.test/test-var #'store-and-retrieve-users-again)
+(clojure.test/test-vars [#'store-and-retrieve-users-again])

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "3.1.0"
+(defproject nubank/state-flow "4.0.0"
   :description "Integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}

--- a/src/state_flow/api.clj
+++ b/src/state_flow/api.clj
@@ -1,0 +1,24 @@
+(ns state-flow.api
+  (:require [state-flow.vendor.potemkin :refer [import-vars import-fn]]
+            [state-flow.core]
+            [state-flow.state]
+            [state-flow.cljtest]
+            [state-flow.assertions.matcher-combinators]))
+
+(import-vars
+ state-flow.core/flow
+ state-flow.core/run
+ state-flow.core/run*
+ state-flow.core/log-and-throw-error!
+ state-flow.core/ignore-error
+
+ state-flow.state/invoke
+ state-flow.state/return
+ state-flow.state/fmap
+
+ state-flow.cljtest/defflow
+
+ state-flow.assertions.matcher-combinators/match?)
+
+(import-fn state-flow.state/gets   get-state)
+(import-fn state-flow.state/modify swap-state)

--- a/src/state_flow/cljtest.clj
+++ b/src/state_flow/cljtest.clj
@@ -15,7 +15,8 @@
     `(~'state-flow.assertions.matcher-combinators/match? ~expected ~actual ~params*)))
 
 (defmacro defflow
-  {:arglists '([name & flows]
+  {:doc "Creates a flow and binds it a Var named by name"
+   :arglists '([name & flows]
                [name parameters & flows])}
   [name & forms]
   (let [[parameters & flows] (if (map? (first forms))

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -113,33 +113,6 @@
   [s]
   (-> s meta :top-level-description))
 
-(defn return
-  "Creates a flow that returns v. Use this as the last
-  step in a flow that you want to reuse in other flows, in
-  order to clarify the return value, e.g.
-
-    (def increment-count
-      (flow \"increments :count and returns it\"
-        (state/modify update :count inc)
-        [new-count (state/gets :count)]
-        (state-flow/return new-count)))"
-  [v]
-  (m/return state/short-circuiting-context v))
-
-(def
-  ^{:doc "Creates a flow that returns the application of f to the return of flow"
-    :arglists '([f flow])}
-  fmap
-  m/fmap)
-
-(defn invoke
-  "Creates a flow that invokes a function of no arguments and returns the
-  result. Used to invoke side effects e.g.
-
-     (state-flow.core/invoke #(Thread/sleep 1000))"
-  [my-fn]
-  (state/error-catching-state (fn [s] [(my-fn) s])))
-
 (defn ^:deprecated as-step-fn
   "DEPRECATED with no replacement."
   [flow]

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -80,7 +80,15 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Public API
 
-(defn flow* [{:keys [description caller-meta]} & flows]
+(defn flow*
+  "For use in macros that create flows. Not private (appropriate for
+  helper libraries, for example), but not intended for use directly in
+  flows.
+
+  Creates a flow which is a composite of flows. The calling macro should
+  provide (meta &form) as `:caller-meta` in order to support accurate line
+  number reporting."
+  [{:keys [description caller-meta]} & flows]
   (when-not (string-expr? description)
     (throw (IllegalArgumentException. "The first argument to flow must be a description string")))
   (let [flow-meta caller-meta
@@ -92,7 +100,7 @@
       (m/return ret#))))
 
 (defmacro flow
-  "Defines a flow"
+  "Creates a flow which is a composite of flows."
   {:style/indent :defn}
   [description & flows]
   (apply flow* {:description description
@@ -105,8 +113,35 @@
   [s]
   (-> s meta :top-level-description))
 
-(defn as-step-fn
-  "Transform a flow step into a state transition function"
+(defn return
+  "Creates a flow that returns v. Use this as the last
+  step in a flow that you want to reuse in other flows, in
+  order to clarify the return value, e.g.
+
+    (def increment-count
+      (flow \"increments :count and returns it\"
+        (state/modify update :count inc)
+        [new-count (state/gets :count)]
+        (state-flow/return new-count)))"
+  [v]
+  (m/return state/short-circuiting-context v))
+
+(def
+  ^{:doc "Creates a flow that returns the application of f to the return of flow"
+    :arglists '([f flow])}
+  fmap
+  m/fmap)
+
+(defn invoke
+  "Creates a flow that invokes a function of no arguments and returns the
+  result. Used to invoke side effects e.g.
+
+     (state-flow.core/invoke #(Thread/sleep 1000))"
+  [my-fn]
+  (state/error-catching-state (fn [s] [(my-fn) s])))
+
+(defn ^:deprecated as-step-fn
+  "DEPRECATED with no replacement."
   [flow]
   (fn [s] (state/exec flow s)))
 

--- a/src/state_flow/state.clj
+++ b/src/state_flow/state.clj
@@ -6,7 +6,7 @@
             [cats.protocols :as p]
             [cats.util :as util]))
 
-(declare error-context)
+(declare short-circuiting-context)
 
 (defn- result-or-err [f & args]
   (let [result ((e/wrap (partial apply f)) args)]
@@ -14,23 +14,23 @@
       result
       @result)))
 
-(defn error-state [mfn]
+(defn error-catching-state [mfn]
   (state/state
    (fn [s]
      (let [new-pair ((e/wrap mfn) s)]
        (if (e/failure? new-pair)
          [new-pair s]
          @new-pair)))
-   error-context))
+   short-circuiting-context))
 
-(def error-context
+(def short-circuiting-context
   "Same as state monad context, but short circuits if error happens, place error in return value"
   (reify
     p/Context
 
     p/Functor
     (-fmap [_ f fv]
-      (error-state
+      (error-catching-state
        (fn [s]
          (let [[v s'] ((p/-extract fv) s)]
            (if (e/failure? v)
@@ -39,10 +39,10 @@
 
     p/Monad
     (-mreturn [_ v]
-      (error-state #(vector v %)))
+      (error-catching-state #(vector v %)))
 
     (-mbind [_ self f]
-      (error-state
+      (error-catching-state
        (fn [s]
          (let [[v s'] ((p/-extract self) s)]
            (if (e/failure? v)
@@ -51,54 +51,56 @@
 
     state/MonadState
     (-get-state [_]
-      (error-state #(vector %1 %1)))
+      (error-catching-state #(vector %1 %1)))
 
     (-put-state [_ newstate]
-      (error-state #(vector % newstate)))
+      (error-catching-state #(vector % newstate)))
 
     (-swap-state [_ f]
-      (error-state #(vector %1 (f %1))))
+      (error-catching-state #(vector %1 (f %1))))
 
     p/Printable
     (-repr [_]
       "#<State-E>")))
 
-(util/make-printable (type error-context))
+(util/make-printable (type short-circuiting-context))
 
 (defn get
-  "Returns the equivalent of (fn [state] [state, state])"
+  "Creates a flow that returns the value of state. "
   []
-  (state/get error-context))
+  (state/get short-circuiting-context))
 
 (defn gets
-  "Returns the equivalent of (fn [state] [state, (apply f state args)])"
+  "Creates a flow that returns the result of applying f to state
+  with any additional args."
   [f & args]
-  (state/gets #(apply f % args) error-context))
+  (state/gets #(apply f % args) short-circuiting-context))
 
 (defn put
-  "Returns the equivalent of (fn [state] [state, new-state])"
+  "Creates a flow that replaces state with new-state. "
   [new-state]
-  (state/put new-state error-context))
+  (state/put new-state short-circuiting-context))
 
 (defn modify
-  "Returns the equivalent of (fn [state] [state, (apply swap! state f args)])"
+  "Creates a flow that replaces state with the result of applying f to
+  state with any additional args."
   [f & args]
-  (state/swap #(apply f % args) error-context))
+  (state/swap #(apply f % args) short-circuiting-context))
 
-(defn return
-  "Returns the equivalent of (fn [state] [v, state])"
+(defn ^:deprecated return
+  "DEPRECATED: use state-flow.core/return instead."
   [v]
-  (m/return error-context v))
+  (m/return short-circuiting-context v))
 
 (defn ^:deprecated swap
-  "DEPRECATED: use modify"
+  "DEPRECATED: use state-flow.state/modify instead."
   [f]
   (modify f))
 
-(defn wrap-fn
-  "Wraps a (possibly side-effecting) function to a state monad"
+(defn ^:deprecated wrap-fn
+  "DEPRECATED: Use state-flow.core/invoke instead."
   [my-fn]
-  (error-state (fn [s] [(my-fn) s])))
+  (error-catching-state (fn [s] [(my-fn) s])))
 
 (def state? state/state?)
 (def run state/run)

--- a/src/state_flow/vendor/potemkin.clj
+++ b/src/state_flow/vendor/potemkin.clj
@@ -1,0 +1,128 @@
+(ns ^:no-doc state-flow.vendor.potemkin)
+
+;; --- copied from ztellman/potemkin
+;;
+;; Copyright (c) 2013 Zachary Tellman
+;;
+;; Permission is hereby granted, free of charge, to any person obtaining a copy
+;; of this software and associated documentation files  (the  "Software"), to
+;; deal in the Software without restriction, including without limitation the
+;; rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+;; sell copies of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+;;
+;; The above copyright notice and this permission notice shall be included in
+;; all copies or substantial portions of the Software.
+;;
+;; THE SOFTWARE IS PROVIDED  "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+;; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+;; FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+;; IN THE SOFTWARE.
+;;
+;; ---
+
+;; --- potemkin.namespaces
+
+(defn link-vars
+  "Makes sure that all changes to `src` are reflected in `dst`."
+  [src dst]
+  (add-watch src dst
+    (fn [_ src old new]
+      (alter-var-root dst (constantly @src))
+      (alter-meta! dst merge (dissoc (meta src) :name)))))
+
+(defmacro import-fn
+  "Given a function in another namespace, defines a function with the
+   same name in the current namespace.  Argument lists, doc-strings,
+   and original line-numbers are preserved."
+  ([sym]
+     `(import-fn ~sym nil))
+  ([sym name]
+     (let [vr (resolve sym)
+           m (meta vr)
+           n (or name (:name m))
+           arglists (:arglists m)
+           protocol (:protocol m)]
+       (when-not vr
+         (throw (IllegalArgumentException. (str "Don't recognize " sym))))
+       (when (:macro m)
+         (throw (IllegalArgumentException.
+                  (str "Calling import-fn on a macro: " sym))))
+
+       `(do
+          (def ~(with-meta n {:protocol protocol}) (deref ~vr))
+          (alter-meta! (var ~n) merge (dissoc (meta ~vr) :name))
+          (link-vars ~vr (var ~n))
+          ~vr))))
+
+(defmacro import-macro
+  "Given a macro in another namespace, defines a macro with the same
+   name in the current namespace.  Argument lists, doc-strings, and
+   original line-numbers are preserved."
+  ([sym]
+     `(import-macro ~sym nil))
+  ([sym name]
+     (let [vr (resolve sym)
+           m (meta vr)
+           n (or name (with-meta (:name m) {}))
+           arglists (:arglists m)]
+       (when-not vr
+         (throw (IllegalArgumentException. (str "Don't recognize " sym))))
+       (when-not (:macro m)
+         (throw (IllegalArgumentException.
+                  (str "Calling import-macro on a non-macro: " sym))))
+       `(do
+          (def ~n ~(resolve sym))
+          (alter-meta! (var ~n) merge (dissoc (meta ~vr) :name))
+          (.setMacro (var ~n))
+          (link-vars ~vr (var ~n))
+          ~vr))))
+
+(defmacro import-def
+  "Given a regular def'd var from another namespace, defined a new var with the
+   same name in the current namespace."
+  ([sym]
+     `(import-def ~sym nil))
+  ([sym name]
+     (let [vr (resolve sym)
+           m (meta vr)
+           n (or name (:name m))
+           n (with-meta n (if (:dynamic m) {:dynamic true} {}))
+           nspace (:ns m)]
+       (when-not vr
+         (throw (IllegalArgumentException. (str "Don't recognize " sym))))
+       `(do
+          (def ~n @~vr)
+          (alter-meta! (var ~n) merge (dissoc (meta ~vr) :name))
+          (link-vars ~vr (var ~n))
+          ~vr))))
+
+(defmacro import-vars
+  "Imports a list of vars from other namespaces."
+  [& syms]
+  (let [unravel (fn unravel [x]
+                  (if (sequential? x)
+                    (->> x
+                         rest
+                         (mapcat unravel)
+                         (map
+                          #(symbol
+                            (str (first x)
+                                 (when-let [n (namespace %)]
+                                   (str "." n)))
+                            (name %))))
+                    [x]))
+        syms (mapcat unravel syms)]
+    `(do
+       ~@(map
+          (fn [sym]
+            (let [vr (resolve sym)
+                  m (meta vr)]
+              (cond
+               (:macro m) `(import-macro ~sym)
+               (:arglists m) `(import-fn ~sym)
+               :else `(import-def ~sym))))
+          syms))))

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -276,3 +276,21 @@
     (is (identical? custom-runner
                     (first (state-flow/run* {:runner custom-runner}
                              (state-flow/runner)))))))
+
+(deftest fmap
+  (is (= 1
+         (first (state-flow/run
+                  (state-flow/fmap (comp inc :count) (state/get))
+                  {:count 0})))))
+
+(deftest return
+  (testing "creates a flow"
+    (is (state/state? (state-flow/return 37))))
+  (testing "returns the value"
+    (is (= [37 2] (state/run (state-flow/return 37) 2)))))
+
+(deftest invoke
+  (testing "creates a flow"
+    (is (state/state? (state-flow/invoke (constantly "hello")))))
+  (testing "invokes a no-arg fn and returns its value"
+    (is (= ["hello" 2] (state/run (state-flow/invoke (constantly "hello")) 2)))))

--- a/test/state_flow/state_test.clj
+++ b/test/state_flow/state_test.clj
@@ -5,17 +5,21 @@
             [state-flow.state :as state]))
 
 (deftest primitives
+  (testing "all primitives are flows"
+    (is (state/state? (state/get)))
+    (is (state/state? (state/gets inc)))
+    (is (state/state? (state/modify inc)))
+    (is (state/state? (state/put {:count 0})))
+    (is (state/state? (state/return 37)))
+    (is (state/state? (state/invoke (constantly "hello")))))
+
   (testing "primitives returns correct values"
     (is (= [2 2] (state/run (state/get) 2)))
     (is (= [3 2] (state/run (state/gets inc) 2)))
     (is (= [2 3] (state/run (state/modify inc) 2)))
-    (is (= [2 3] (state/run (state/put 3) 2))))
-
-  (testing "all primitives are states"
-    (is (state/state? (state/get)))
-    (is (state/state? (state/gets inc)))
-    (is (state/state? (state/modify inc)))
-    (is (state/state? (state/put {:count 0})))))
+    (is (= [2 3] (state/run (state/put 3) 2)))
+    (is (= [37 2] (state/run (state/return 37) 2)))
+    (is (= ["hello" 2] (state/run (state/invoke (constantly "hello")) 2)))))
 
 (deftest exception-handling
   (let [double-state (state/modify * 2)]
@@ -75,3 +79,9 @@
     (is (= [{:count 1} {:count 0}]
            (state/run (state/gets #(update % :count inc)) {:count 0})
            (state/run (state/gets update :count inc) {:count 0})))))
+
+(deftest fmap
+  (is (= 1
+         (first (state/run
+                  (state/fmap (comp inc :count) (state/get))
+                  {:count 0})))))

--- a/test/state_flow/state_test.clj
+++ b/test/state_flow/state_test.clj
@@ -9,17 +9,13 @@
     (is (= [2 2] (state/run (state/get) 2)))
     (is (= [3 2] (state/run (state/gets inc) 2)))
     (is (= [2 3] (state/run (state/modify inc) 2)))
-    (is (= [37 2] (state/run (state/return 37) 2)))
-    (is (= [2 3] (state/run (state/put 3) 2)))
-    (is (= ["hello" 2] (state/run (state/wrap-fn (constantly "hello")) 2))))
+    (is (= [2 3] (state/run (state/put 3) 2))))
 
   (testing "all primitives are states"
     (is (state/state? (state/get)))
     (is (state/state? (state/gets inc)))
     (is (state/state? (state/modify inc)))
-    (is (state/state? (state/return 37)))
-    (is (state/state? (state/put {:count 0})))
-    (is (state/state? (state/wrap-fn (constantly "hello"))))))
+    (is (state/state? (state/put {:count 0})))))
 
 (deftest exception-handling
   (let [double-state (state/modify * 2)]


### PR DESCRIPTION
This is take 2 of #117, which originally started as "let's add fmap somewhere"

## state-flow.api

Introduce a new `state-flow.api` namespace which imports the following vars:

``` clojure


;; from state-flow.core
flow
run
run*
log-and-throw-error!
ignore-error

;; from state-flow.state
get-state  ;; state/gets
swap-state ;; state/modify
invoke     ;; formerly wrap-fn
return
fmap       ;; new addition

;; from state-flow.cljtest
defflow

;; from state-flow.assertions.matcher-combinators/
match?
```

## Deprecates

* state/wrap-fn (replaced by state/invoke)

## Also

* improves/clarifies some docstrings

## Rationale:

We wanted to add `fmap` and decided it made more sense in `core` than in `state`. While reviewing this, we realized that `state/return` and `state/wrap-fn` have little to do with state, so they probably belonged in `core` as well, and we found that the name `wrap-fn` was confusing, hence `invoke`.

The same conversation also revealed that there is some pain in having to require 4 namespaces in order to use state-flow in its most common use at Nubank: with clojure.test and matcher-combinators. That's what led us to the `api` namespace.

## TODO

- [x] consider recommending aliasing `[state-flow.api :as flow]`
  - that would put nice things like `flow/invoke` and `flow/return` in flows.
- [x] update README
- [x] update walkthrough