### PR TITLE
move match? exception to flow execution time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [4.0.3]
 
-* `match?` throws `times-to-try` warning at runtime instead of macro-expansion time [#125](https://github.com/nubank/state-flow/pull/125)
+* `state-flow.api/match?` throws `times-to-try` exception at runtime instead of macro-expansion time [#125](https://github.com/nubank/state-flow/pull/125)
+  * The deprecated `state-flow.cljtest/match?` no longer throws that exception at all.
 
 ## [4.0.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [4.0.3]
+
+* `match?` throws `times-to-try` warning at runtime instead of macro-expansion time [#125](https://github.com/nubank/state-flow/pull/125)
+
 ## [4.0.2]
 
 * Make sure Intellij can find the vars imported in api ns.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "4.0.2"
+(defproject nubank/state-flow "4.0.3"
   :description "Integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}

--- a/src/state_flow/assertions/matcher_combinators.clj
+++ b/src/state_flow/assertions/matcher_combinators.clj
@@ -57,11 +57,7 @@
                                  :times-to-try 1
                                  :sleep-time   probe/default-sleep-time}
                                 params)]
-    (when (and ((fnil > 1) times-to-try 1)
-               (not (state/state? (eval actual))))
-      (throw (ex-info "actual must be a step or a flow when :times-to-try > 1"
-                      {:times-to-try times-to-try
-                       :actual (eval actual)})))
+
     (core/flow*
      {:description (:description params*)
       :caller-meta (:caller-meta params*)}
@@ -69,6 +65,11 @@
      ;; a bit ugly, but it supports getting the correct line number
      ;; information from core/current-description.
      `(m/do-let
+       (state/invoke #(when (and ((fnil > 1) ~times-to-try 1)
+                                 (not (state/state? ~actual)))
+                        (throw (ex-info "actual must be a step or a flow when :times-to-try > 1"
+                                        {:times-to-try ~times-to-try
+                                         :actual ~actual}))))
        [flow-desc# (core/current-description)
         probe-res# (#'match-probe (state/ensure-step ~actual) ~expected ~params*)
         :let [actual# (-> probe-res# last :value)
@@ -81,7 +82,7 @@
        ;; TODO: (dchelimsky, 2020-02-11) we plan to decouple
        ;; assertions from reporting in a future release. Remove this
        ;; next line when that happens.
-       (state/wrap-fn #(~'clojure.test/testing flow-desc# (~'clojure.test/is (~'match? ~expected actual#))))
+       (state/invoke #(~'clojure.test/testing flow-desc# (~'clojure.test/is (~'match? ~expected actual#))))
        (state/return report#)))))
 
 (defn report->actual

--- a/src/state_flow/assertions/matcher_combinators.clj
+++ b/src/state_flow/assertions/matcher_combinators.clj
@@ -65,7 +65,8 @@
      ;; a bit ugly, but it supports getting the correct line number
      ;; information from core/current-description.
      `(m/do-let
-       (state/invoke #(when (and ((fnil > 1) ~times-to-try 1)
+       (state/invoke #(when (and (not (:called-from-deprecated-match? ~params*))
+                                 ((fnil > 1) ~times-to-try 1)
                                  (not (state/state? ~actual)))
                         (throw (ex-info "actual must be a step or a flow when :times-to-try > 1"
                                         {:times-to-try ~times-to-try

--- a/src/state_flow/cljtest.clj
+++ b/src/state_flow/cljtest.clj
@@ -10,7 +10,8 @@
   (let [params* (merge {:times-to-try probe/default-times-to-try
                         :sleep-time   probe/default-sleep-time
                         :caller-meta  (meta &form)
-                        :description  match-desc}
+                        :description  match-desc
+                        :called-from-deprecated-match? true}
                        params)]
     `(~'state-flow.assertions.matcher-combinators/match? ~expected ~actual ~params*)))
 

--- a/test/state_flow/assertions/matcher_combinators_test.clj
+++ b/test/state_flow/assertions/matcher_combinators_test.clj
@@ -101,11 +101,12 @@
   (testing "with times-to-try > 1 and a value instead of a step"
     (testing "throws"
       (is (re-find #"actual must be a step or a flow when :times-to-try > 1"
-                   (.. (try
-                         (eval `(mc/match? 3 (+ 30 7) {:times-to-try 2}))
-                         (catch Exception e e))
-                       getCause
-                       getMessage))))))
+                   (.getMessage
+                    (:failure
+                     (first
+                      (try
+                        (state/run (mc/match? 3 (+ 30 7) {:times-to-try 2}) {})
+                        (catch Exception e e))))))))))
 
 (deftest test-report->actual
   (is (= :actual

--- a/test/state_flow/cljtest_test.clj
+++ b/test/state_flow/cljtest_test.clj
@@ -62,3 +62,13 @@
   (is (match? {:value 1
                :map   {:a 1 :b 2}}
               (second ((:test (meta #'my-flow)))))))
+
+(deftest test-deprecated-match?
+  (testing "with times-to-try > 1 and a value instead of a step"
+    (testing "does not throw (to preserve backward compatibility)"
+      (is (= :match
+             (:match/result
+              (state/eval (state-flow.cljtest/match? "description"
+                                                     3
+                                                     3
+                                                     {:times-to-try 2}) {})))))))


### PR DESCRIPTION
Before this PR `match?` would raise an exception at macroexpansion time if it was called in a syntactically correct by semantically incorrect way. With this PR, the update happens at flow execution time instead.

Additionally, in order to reduce upgrade friction, that exception is not thrown at all when calling the deprecated `state-flow.cljtest/match?` fn.