### PR TITLE
improve error message when last arg to flow is a vector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [5.1.0]
+
+* improve error message when last arg to flow is a vector [#128](https://github.com/nubank/state-flow/pull/128)
+
 ## [5.0.0]
 
 * upgrade to matcher-combinators-2.0.0
@@ -13,7 +17,7 @@ See https://github.com/nubank/matcher-combinators/blob/master/CHANGELOG.md#200
 
 ## [4.0.3]
 
-* `state-flow.api/match?` throws `times-to-try` exception at runtime instead of macro-expansion time [#125](https://github.com/nubank/state-flow/pull/125)
+* `state-flow.api/match?` throws `times-to-try` exception a runtime instead of macro-expansion time [#125](https://github.com/nubank/state-flow/pull/125)
   * The deprecated `state-flow.cljtest/match?` no longer throws that exception at all.
 
 ## [4.0.2]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "5.0.0"
+(defproject nubank/state-flow "5.1.0"
   :description "Integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -91,6 +91,8 @@
   [{:keys [description caller-meta]} & flows]
   (when-not (string-expr? description)
     (throw (IllegalArgumentException. "The first argument to flow must be a description string")))
+  (when (vector? (last flows))
+    (throw (ex-info "The last argument to flow must be a flow/step, not a binding vector." {})))
   (let [flow-meta caller-meta
         flows'    (or flows `[(m/return nil)])]
     `(m/do-let

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -29,6 +29,21 @@
 (def empty-flow
   (flow "empty"))
 
+(deftest test-flow
+  (testing "flow without description fails at macro-expansion time"
+    (is (re-find #"first argument .* must be .* description string"
+                 (try
+                   (macroexpand `(flow (state/return {})))
+                   (catch clojure.lang.Compiler$CompilerException e
+                     (.. e getCause getMessage))))))
+
+  (testing "flow with vector as last argument fails at macro-expansion time"
+    (is (re-find #"last argument .* must be a flow/step"
+                 (try
+                   (macroexpand `(flow "" [x (state/get-state)]))
+                   (catch clojure.lang.Compiler$CompilerException e
+                     (.. e getCause getMessage)))))))
+
 (deftest run-flow
   (testing "default initial state is an empty map"
     (is (= {}
@@ -49,12 +64,7 @@
   (testing "empty flow runs without exception"
     (is (nil? (first (state-flow/run empty-flow {})))))
 
-  (testing "flow without description fails at macro-expansion time"
-    (is (re-find #"first argument .* must be .* description string"
-                 (try
-                   (macroexpand `(flow (state/return {})))
-                   (catch clojure.lang.Compiler$CompilerException e
-                     (.. e getCause getMessage))))))
+
 
   (testing "flow with a `(str ..)` expr for the description is fine"
     (is (macroexpand `(flow (str "foo") [original (state/gets :value)


### PR DESCRIPTION
This PR addresses issue #113 

### Before

```clojure
(flow "description" [x (state/get-state)])
;; Unexpected error (AssertionError) macroexpanding cats.core/do-let at (....).
;; Assert failed: Last argument of do-let must not be a vector
;; (not (vector? (last forms)))
```

### After

```clojure
(flow "description" [x (state/get-state)])
;; Syntax error macroexpanding state-flow.core/flow at (...).
;; The last argument to flow must be a flow/step, not a binding vector.
```
