### PR TITLE
Add error handler to filter stack trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [5.2.0]
+
+* add stack-trace filtering [#129](https://github.com/nubank/state-flow/pull/129)
+
 ## [5.1.0]
 
 * improve error message when last arg to flow is a vector [#128](https://github.com/nubank/state-flow/pull/128)

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "5.1.0"
+(defproject nubank/state-flow "5.2.0"
   :description "Integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -219,7 +219,7 @@
 
                     `(comp throw-error!
                            log-error
-                           (filter-stack-trace))`"
+                           (filter-stack-trace default-strack-trace-exclusions))`"
   [{:keys [init cleanup runner on-error]
     :or   {init                   (constantly {})
            cleanup                identity

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -129,19 +129,30 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Error handlers
 
-(defn log-and-throw-error!
-  "Error handler that logs the error and throws an exception to notify the flow
-  has failed."
+(defn ignore-error
+  "No-op error handler that ignores the error."
+  [pair]
+  pair)
+
+(defn log-error
+  "Error handler that logs error and returns pair."
   [pair]
   (let [description (state->current-description (second pair))
         message     (str "Flow " "\"" description "\"" " failed with exception")]
     (log/info (m/extract (first pair)) message)
+    pair))
+
+(defn throw-error!
+  "Error handler that throws the error."
+  [pair]
+  (let [description (state->current-description (second pair))
+        message     (str "Flow " "\"" description "\"" " failed with exception")]
     (throw (ex-info message {} (m/extract (first pair))))))
 
-(defn ignore-error
-  "No-op error handler that simply ignores the error."
+(defn ^:deprecated log-and-throw-error!
+  "DEPRECATED: Use (comp throw-error! log-error) instead. "
   [pair]
-  pair)
+  (-> pair log-error throw-error!))
 
 (def default-stack-trace-exclusions
   [#"^nrepl\."
@@ -151,7 +162,7 @@
    #"^clojure\.main\$repl"
    #"^clojure\.lang"])
 
-(defn filter-stack-trace
+(defn- filter-stack-trace*
   "Given a seq of exclusions (regexen) and a StackTraceElement array,
   returns a new StackTraceElement array which excludes all elements
   whose class names match any of the exclusions."
@@ -164,14 +175,21 @@
                 (rest frames)))
          into-array)))
 
-(defn with-filtered-stack-trace [exclusions pair]
-  (if-let [failure (some->> pair first :failure)]
-    [(#'cats.monad.exception/->Failure
-      (doto failure
-        (.setStackTrace
-         (filter-stack-trace exclusions (.getStackTrace failure)))))
-     (second pair)]
-    pair))
+(defn filter-stack-trace
+  "Returns an error handler which, if the first element in the pair is
+  a failure, returns the pair with the failure's stack-trace
+  filtered, else returns the pair as/is."
+  ([]
+   (filter-stack-trace default-stack-trace-exclusions))
+  ([exclusions]
+   (fn [pair]
+     (if-let [failure (some->> pair first :failure)]
+       [(#'cats.monad.exception/->Failure
+         (doto failure
+           (.setStackTrace
+            (filter-stack-trace* exclusions (.getStackTrace failure)))))
+        (second pair)]
+       pair))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Runners
@@ -193,25 +211,27 @@
 
   Supported keys in the first argument are:
 
-    `:init`                   optional, default (constantly {}), function of no arguments that returns the initial state
-    `:cleanup`                optional, default identity, function of the final state used to perform cleanup, if necessary
-    `:runner`                 optional, default `run`, function of a flow and an initial state which will execute the flow
-    `:on-error`               optional, default `log-and-throw-error!`, function of the final result pair to be invoked
-                              when the first value in the pair represents an error
-    `:stack-trace-exclusions` optional, default `default-stack-trace-exclussions`, sequence of regular expressions
-                              used to clean stack traces"
-  [{:keys [init cleanup runner on-error stack-trace-exclusions]
+    `:init`       optional, default (constantly {}), function of no arguments that returns the initial state
+    `:cleanup`    optional, default identity, function of the final state used to perform cleanup, if necessary
+    `:runner`     optional, default `run`, function of a flow and an initial state which will execute the flow
+    `:on-error`   optional, function of the final result pair to be invoked when the first value in the pair
+                  represents an error, default:
+
+                    `(comp throw-error!
+                           log-error
+                           (filter-stack-trace))`"
+  [{:keys [init cleanup runner on-error]
     :or   {init                   (constantly {})
            cleanup                identity
            runner                 run
-           on-error               log-and-throw-error!
-           stack-trace-exclusions default-stack-trace-exclusions}
+           on-error               (comp throw-error!
+                                        log-error
+                                        (filter-stack-trace default-stack-trace-exclusions))}
     :as   opts}
    flow]
   (let [initial-state (init)
-        pair          (->> (runner flow (vary-meta initial-state assoc :runner runner))
-                           clarify-illegal-arg
-                           (with-filtered-stack-trace stack-trace-exclusions))]
+        pair          (clarify-illegal-arg (runner flow
+                                             (vary-meta initial-state assoc :runner runner)))]
     (try
       (cleanup (second pair))
       pair

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -178,7 +178,11 @@
 (defn filter-stack-trace
   "Returns an error handler which, if the first element in the pair is
   a failure, returns the pair with the failure's stack-trace
-  filtered, else returns the pair as/is."
+  filtered, else returns the pair as/is.
+
+  exclusions (default default-stack-trace-exclusions) is a sequence of
+  regular expressions used to match class names in stack trace frames.
+  Matching frames are excluded."
   ([]
    (filter-stack-trace default-stack-trace-exclusions))
   ([exclusions]

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -286,3 +286,23 @@
     (is (identical? custom-runner
                     (first (state-flow/run* {:runner custom-runner}
                              (state-flow/runner)))))))
+
+(deftest stack-trace-exclusions
+  (testing "exclude state_flow by default"
+    (is (empty? (->> (state-flow/run* {:on-error state-flow/ignore-error}
+                       (state-flow/flow "" (state/modify assoc :x (/ 1 0))))
+                     first
+                     :failure
+                     .getStackTrace
+                     (into [])
+                     (filter #(re-find #"state_flow" (.getClassName %)))))))
+
+  (testing "can be overridden via :state-trace-exclusions"
+    (is (seq (->> (state-flow/run* {:on-error state-flow/ignore-error
+                                    :stack-trace-exclusions []}
+                    (state-flow/flow "" (state/modify assoc :x (/ 1 0))))
+                  first
+                  :failure
+                  .getStackTrace
+                  (into [])
+                  (filter #(re-find #"state_flow" (.getClassName %))))))))

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -144,7 +144,8 @@
     ;; TODO:(dchelimsky,2020-03-02) consider whether we should catch this
     ;; instead of letting it bubble out.
     (is (thrown-with-msg? Exception #"Oops"
-                          (state-flow/run* {:runner (constantly (throw (ex-info "Oops" {})))}
+                          (state-flow/run*
+                            {:runner (constantly (throw (ex-info "Oops" {})))}
                             (state/get))))))
 
 (deftest state-flow-run!
@@ -290,7 +291,8 @@
 (deftest stack-trace-exclusions
   (testing "default: uses default-stack-trace-exceptions (on all but first frame)"
     (let [frames (->> (state-flow/run*
-                        {:on-error state-flow/ignore-error}
+                        {:on-error (state-flow/filter-stack-trace
+                                    state-flow/default-stack-trace-exclusions)}
                         (state-flow/flow "" (state/invoke (/ 1 0))))
                       first
                       :failure
@@ -302,8 +304,7 @@
 
   (testing "preserves the first frame even if it matches exclusions"
     (let [frames (->> (state-flow/run*
-                        {:on-error               state-flow/ignore-error
-                         :stack-trace-exclusions [#"clojure.lang"]}
+                        {:on-error (state-flow/filter-stack-trace [#"clojure.lang"])}
                         (state-flow/flow "" (state/invoke (/ 1 0))))
                       first
                       :failure


### PR DESCRIPTION
This PR:

* breaks up `log-and-throw-error!` into `log-error` and `throw-error`
    * `log-and-throw-error!` is deprecated, not removed
* makes the default `:on-error` in `state-flow.api/run*` a composition of:
    `(comp throw-error! log-error (filter-stack-trace default-stack-trace-exclusions))`
* you can override this with any of those handlers or any comp of them e.

```clojure
(run* {:on-error ignore-error} flow)
(run* {:on-error (comp log-error (filter-strack-trace))} flow)
```

* you can also override the stack-trace-exclusions e.g.

```clojure
(run* {:on-error (comp log-error (filter-strack-trace [#"clojure.lang"]))} flow)
``` 

### Before (defaults)

```clojure
user> (flow/run* {} (flow/flow "" (flow/invoke (/ 1 0))))
20-06-15 15:23:48 MacBook-Pro.local INFO [state-flow.core:142] - Flow "" failed with exception
nrepl.middleware.interruptible-eval/evaluate/fn  interruptible_eval.clj:   91
                              clojure.core/eval                core.clj: 3214
                                            ...
                                 user/eval26881               REPL Input
                           state-flow.core/run*                core.clj:  233
                            state-flow.core/run                core.clj:  205
                           cats.monad.state/run              state.cljc:  147
       state-flow.state/error-catching-state/fn               state.clj:   20
                                            ...
                   cats.monad.exception/wrap/fn          exception.cljc:  250
               cats.monad.exception/exec-try-on          exception.cljc:  197
      cats.monad.exception/wrap/fn/func--auto--          exception.cljc:  250
                             clojure.core/apply                core.clj:  665
                                            ...
                      state-flow.state/reify/fn               state.clj:   50
                              cats.core/bind/fn               core.cljc:   96
                              user/eval26881/fn               REPL Input
                                            ...
java.lang.ArithmeticException: Divide by zero

Execution error (ArithmeticException) at user/eval26881$fn (form-init8086161948397246332.clj:225).
Divide by zero
```

### After (defaults)

``` clojure
user> (flow/run* {} (flow/flow "" (flow/invoke (/ 1 0))))
20-06-15 15:23:05 MacBook-Pro.local INFO [state-flow.core:142] - Flow "" failed with exception
                       clojure.core/eval   core.clj: 3214
                          user/eval26794  REPL Input
                    state-flow.core/run*   core.clj:  233
                     state-flow.core/run   core.clj:  205
state-flow.state/error-catching-state/fn  state.clj:   20
                      clojure.core/apply   core.clj:  665
               state-flow.state/reify/fn  state.clj:   50
                       user/eval26794/fn  REPL Input
                                     ...
java.lang.ArithmeticException: Divide by zero

Execution error (ArithmeticException) at user/eval26794$fn (form-init8086161948397246332.clj:210).
Divide by zero

```

