### PR TITLE
support n flows to with-redefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [5.5.0]
+
+* support n flows passed to `state-flow.labs.state/with-redefs` [#133](https://github.com/nubank/state-flow/pull/133)
+
 ## [5.4.0]
 
 * upgrade to [matcher-combinators-3.0.1](https://github.com/nubank/matcher-combinators/blob/master/CHANGELOG.md#301)

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "5.4.0"
+(defproject nubank/state-flow "5.5.0"
   :description "Integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}

--- a/src/state_flow/labs/state.clj
+++ b/src/state_flow/labs/state.clj
@@ -2,9 +2,8 @@
   "WARNING: This API is experimental and subject to changes."
   (:refer-clojure :exclude [with-redefs])
   (:require [cats.core :as m]
-            state-flow.api
-            [state-flow.core :as state-flow]
-            [state-flow.state :as state]))
+            [state-flow.api :as flow]
+            [state-flow.core :as state-flow]))
 
 (defmacro wrap-with
   "WARNING: `wrap-with` usage is not recommended. Use only if you know what you're
@@ -14,11 +13,11 @@
   function that will run the flow when called."
   [wrapper-fn flow]
   `(m/do-let
-    [world#  (state/get)
+    [world#  (flow/get-state)
      runner# (state-flow/runner)
      :let [[ret# state#] (~wrapper-fn (fn [] (runner# ~flow world#)))]]
-    (state-flow.api/swap-state (constantly state#))
-    (state/return ret#)))
+    (flow/swap-state (constantly state#))
+    (flow/return ret#)))
 
 (defmacro with-redefs
   "WARNING: `with-redefs` usage is not recommended. Use only if you know what you're
@@ -33,7 +32,7 @@
         [now (constantly #inst \"2018-01-01\")]
         (flow \"a flow in 2018\"
               ...)))"
-  [bindings flow]
+  [bindings & flows]
   `(wrap-with
     (fn [f#] (clojure.core/with-redefs ~bindings (f#)))
-    ~flow))
+    (flow/flow "with-redefs" ~@flows)))


### PR DESCRIPTION
Before you could only pass one flow to `with-redefs`, which often required wrapping multiple flows. Now that is done for us:

```clojure
(state-flow.labs.state/with-redefs [<sym> <redef>]
  (flow "one flow" ...)
  (flow "another flow" ...))
```