### PR TITLE
downgrade timbre after recent major version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [5.6.1]
+
+* downgrade timbre logging library major version bump that was done in `5.6.0` because it is causing transient issues.
+
 ## [5.6.0]
 
 * create the `:fail-fast?` options for `run*`. When set the flow will failing fast on the first assertion instead of continuing to run

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "5.6.0"
+(defproject nubank/state-flow "5.6.1"
   :description "Integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}
@@ -19,7 +19,7 @@
             [changelog-check "0.1.0"]]
 
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [com.taoensso/timbre "5.0.1"]
+                 [com.taoensso/timbre "4.10.0"]
                  [funcool/cats "2.3.6"]
                  [nubank/matcher-combinators "3.1.3"]]
 


### PR DESCRIPTION
https://github.com/nubank/state-flow/pull/138 bumped timbre a major version and it is causing some issues on services. I don't really want to deal with it at the moment, so I'll simply downgrade

```
12:08:43,215 |-INFO in ch.qos.logback.classic.joran.action.ConfigurationAction - End of configuration.
12:08:43,217 |-INFO in ch.qos.logback.classic.joran.JoranConfigurator@6982fae - Registering current configuration as safe fallback point
Syntax error compiling at (taoensso/timbre/appenders/core.cljc:30:4).
No such var: enc/system-newline
```