### PR TITLE
add flow/for macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,28 @@ a system using [Stuart Sierra's Component](https://github.com/stuartsierra/compo
 (state-flow.api/run* {:init (constantly {:service-system (atom nil))} flow)
 ```
 
+### Composing Flows
+
+Flows follow the Composite Pattern: a single flow has the same
+interface as a collection of flows.
+
+You can compose flows by nesting them in other flows:
+
+``` clojure
+(flow "do many things"
+  (flow "do one thing" ,,,)
+  (flow "do another thing" ,,,))
+```
+
+Use `state-flow.api/for` when you have a flow that you'd like to apply
+to different inputs with the same outcome, e.g.
+
+``` clojure
+(flow "even? returns true for even numbers"
+  (flow/for [x (filter even? (range 10))]
+    (match? even? x)))
+```
+
 #### Failing Fast
 
 By default, a flow continues to be evaluated even if an assertion fails. The `:fail-fast?` option to `state-flow.api/run*` can be used if you would like to stop evaluation after the first assertion failure.
@@ -115,7 +137,6 @@ By default, a flow continues to be evaluated even if an assertion fails. The `:f
     failing-flow-b
     flow-c))
 ```
-
 
 ### Flow Example
 
@@ -350,16 +371,7 @@ monads in Clojure. `state-flow` exposes some, but not all, `cats`
 functions as its own API. As mentioned above, we recommend that you
 stick with `state-flow` functions as much as possible, however, if the
 available functions do not suit your need for a helper, you can always
-drop down to functions directly in the `cats` library. For example,
-let's say you want to execute a step `n` times. You could use the
-`cats.core/sequence` function directly
-
-``` clojure
-(state-flow.api/run
-  (flow "x"
-      (cats.core/sequence (repeat 5 (state-flow.api/swap-state update :count inc))))
-  {:count 0})
-```
+drop down to functions directly in the `cats` library.
 
 ## Tooling
 

--- a/src/state_flow/api.clj
+++ b/src/state_flow/api.clj
@@ -1,5 +1,7 @@
 (ns state-flow.api
-  (:require [state-flow.assertions.matcher-combinators]
+  (:refer-clojure :exclude [for])
+  (:require [cats.core :as m]
+            [state-flow.assertions.matcher-combinators]
             [state-flow.cljtest]
             [state-flow.core]
             [state-flow.state]
@@ -38,3 +40,22 @@
 
 (import-fn state-flow.state/gets   get-state)
 (import-fn state-flow.state/modify swap-state)
+
+(defmacro for
+  "Like clojure.core/for, but returns a flow which wraps a sequence of flows e.g.
+
+     (flow \"even? returns true for even numbers\"
+       (flow/for [x (filter even? (range 10))]
+         (match? even? x)))
+
+     ;; same as
+
+   (flow \"even? returns true for even numbers\"
+     (match? even? 0)
+     (match? even? 2)
+     (match? even? 4)
+     (match? even? 6)
+     (match? even? 8)) "
+  [seq-exprs flow]
+  `(m/sequence
+    (clojure.core/for ~seq-exprs ~flow)))

--- a/test/state_flow/api_test.clj
+++ b/test/state_flow/api_test.clj
@@ -1,0 +1,11 @@
+(ns state-flow.api-test
+  (:require [clojure.test :as t :refer [deftest is testing]]
+            [state-flow.api :as flow]
+            [state-flow.state :as state]))
+
+(deftest test-for
+  (is (= [1 2 3]
+         (state/eval
+          (flow/for [x [1 2 3]]
+            (flow/return x))
+          {}))))


### PR DESCRIPTION
## Problem: apply the same flow to different sets of inputs

## Some existing solutions:

* defn a fn that returns a flow and invoke it from a defflow

```clojure
(defn a-flow [arg] (flow (str "do something with " arg) ,,,)

(defflow do-something-with-x (a-flow 'x))
(defflow do-something-with-y (a-flow 'y))
;; or
(defflow do-something-with-x-and-y
  (a-flow 'x)
  (a-flow 'y))
```

* use cats.core/sequence directly

```clojure
(defflow do-something-with-x-and-y
  (cats.core/sequence
    (for [z [:x :y]]
      (flow (str "do stuff with " z)
       ,,,
       ))))
```

## Proposal

This PR adds a `state-flow.api/for` macro that works just like `clojure.core/for`, but returns a flow which wraps a sequence of flows, e.g.

```clojure
(defflow do-something-with-x-and-y
  (flow/for [z [:x :y]]
    (flow (str "do stuff with " z)
     ,,,
     ))))
```

TODO:
* [x] more doc