### PR TITLE
Add before flow hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [5.8.0]
+
+* enables the user to add a hook that is executed before flow execution and after description is updated, via the `before-flow-hook` option
+
 ## [5.7.0]
 
 * add `state-flow.api/for` macro [#142](https://github.com/nubank/state-flow/pull/142)

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "5.7.0"
+(defproject nubank/state-flow "5.8.0"
   :description "Integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -86,7 +86,7 @@
 (defn apply-before-flow-hook
   []
   (m/do-let
-   [hook (state/gets #(-> % meta :before-flow-hook))]
+   [hook (state/gets (comp :before-flow-hook meta))]
    (state/modify (or hook identity))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -83,6 +83,12 @@
      (second pair)]
     pair))
 
+(defn apply-before-flow-hook
+  []
+  (m/do-let
+   [hook (state/gets #(-> % meta :before-flow-hook))]
+   (state/modify (or hook identity))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Public API
 
@@ -103,6 +109,7 @@
         flows'    (or flows `[(m/return nil)])]
     `(m/do-let
       (push-meta ~description ~flow-meta)
+      (apply-before-flow-hook)
       [ret# (m/do-let ~@flows')]
       (pop-meta)
       (m/return ret#))))
@@ -230,21 +237,21 @@
 
   Supported keys in the first argument are:
 
-    `:fail-fast?` optional, default `false`, when set to `true`, the flow stops running after the first failing assertion
-    `:init`       optional, default (constantly {}), function of no arguments that returns the initial state
-    `:cleanup`    optional, default identity, function of the final state used to perform cleanup, if necessary
-    `:runner`     optional, default `run`, function of a flow and an initial state which will execute the flow
-    `:on-error`   optional, function of the final result pair to be invoked when the first value in the pair
-                  represents an error, default:
-
-                    `(comp throw-error!
-                           log-error
-                           (filter-stack-trace default-strack-trace-exclusions))`"
-  [{:keys [init cleanup runner on-error fail-fast?]
+    `:fail-fast?`       optional, default `false`, when set to `true`, the flow stops running after the first failing assertion
+    `:init`             optional, default (constantly {}), function of no arguments that returns the initial state
+    `:cleanup`          optional, default `identity`, function of the final state used to perform cleanup, if necessary
+    `:runner`           optional, default `run`, function of a flow and an initial state which will execute the flow
+    `:before-flow-hook` optional, default `identity`, function from state to new-state that is applied before excuting a flow, after flow description is updated.
+    `:on-error`         optional, function of the final result pair to be invoked when the first value in the pair represents an error, default:
+                        `(comp throw-error!
+                              log-error
+                              (filter-stack-trace default-strack-trace-exclusions))`"
+  [{:keys [init cleanup runner on-error fail-fast? before-flow-hook]
     :or   {init                   (constantly {})
            cleanup                identity
            runner                 run
            fail-fast?             false
+           before-flow-hook       identity
            on-error               (comp throw-error!
                                         log-error
                                         (filter-stack-trace default-stack-trace-exclusions))}
@@ -253,6 +260,7 @@
   (let [init-state+meta (vary-meta (init)
                                    assoc
                                    :runner runner
+                                   :before-flow-hook before-flow-hook
                                    :fail-fast? fail-fast?)
         pair            (-> flow
                             (runner init-state+meta)

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -311,3 +311,13 @@
       (is (empty? (->> (rest frames)
                        (map #(.getClassName %))
                        (filter #(re-find #"^clojure.lang" %))))))))
+
+(deftest before-flow-hook
+  (testing "default: uses default-stack-trace-exceptions (on all but first frame)"
+    (let [result (->> (state-flow/run*
+                        {:before-flow-hook (fn [s] (assoc s :my-thing (str (first (clojure.string/split (#'state-flow/state->current-description s)
+                                                                                         #" "))
+                                                                           " world!")))}
+                        (state-flow/flow "hello" (state/gets :my-thing)))
+                      first)]
+      (is (= result "hello world!")))))

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -313,7 +313,7 @@
                        (filter #(re-find #"^clojure.lang" %))))))))
 
 (deftest before-flow-hook
-  (testing "default: uses default-stack-trace-exceptions (on all but first frame)"
+  (testing "add a custom before-flow-hook that gets a description and changes the state with a modified version of it"
     (let [result (->> (state-flow/run*
                        {:before-flow-hook (fn [s] (assoc s :my-thing (str (first (clojure.string/split (#'state-flow/state->current-description s)
                                                                                                        #" "))

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -315,9 +315,9 @@
 (deftest before-flow-hook
   (testing "default: uses default-stack-trace-exceptions (on all but first frame)"
     (let [result (->> (state-flow/run*
-                        {:before-flow-hook (fn [s] (assoc s :my-thing (str (first (clojure.string/split (#'state-flow/state->current-description s)
-                                                                                         #" "))
-                                                                           " world!")))}
-                        (state-flow/flow "hello" (state/gets :my-thing)))
+                       {:before-flow-hook (fn [s] (assoc s :my-thing (str (first (clojure.string/split (#'state-flow/state->current-description s)
+                                                                                                       #" "))
+                                                                          " world!")))}
+                       (state-flow/flow "hello" (state/gets :my-thing)))
                       first)]
       (is (= result "hello world!")))))


### PR DESCRIPTION
This change enables the user to add a hook that is executed before flow execution and after description is updated.

One example of use case is allowing access from third-party tools of the description stack at run-time

Solves https://github.com/nubank/state-flow/issues/136