### PR TITLE
Add filename to flow descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [5.9.0]
+
+* add filename to flow descriptions. Use the following format: `<description> (<file>:<line>)`
+
 ## [5.8.0]
 
 * enables the user to add a hook that is executed before flow execution and after description is updated, via the `before-flow-hook` option

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "5.8.0"
+(defproject nubank/state-flow "5.9.0"
   :description "Integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,4 @@
 (defproject nubank/state-flow "5.9.0"
-(defproject nubank/state-flow "5.8.1"
   :description "Integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}

--- a/src/state_flow/assertions/matcher_combinators.clj
+++ b/src/state_flow/assertions/matcher_combinators.clj
@@ -59,7 +59,7 @@
                             :caller-meta  caller-meta
                             :times-to-try 1
                             :sleep-time   probe/default-sleep-time}
-                                params)]
+                           params)]
 
     (core/flow*
      {:description (:description params*)

--- a/src/state_flow/assertions/matcher_combinators.clj
+++ b/src/state_flow/assertions/matcher_combinators.clj
@@ -52,11 +52,13 @@
    ;; deprecated cljtest/match? fn.  Undecided
    ;; whether we want to make it part of the API.
    ;; caller-meta is definitely not part of the API.
-  (let [caller-meta      (meta &form)
-        params*          (merge {:description  "match?"
-                                 :caller-meta  caller-meta
-                                 :times-to-try 1
-                                 :sleep-time   probe/default-sleep-time}
+  (let [f           *file*
+        a-ns        (str *ns*)
+        caller-meta (assoc (meta &form) :file f :ns a-ns)
+        params*     (merge {:description  "match?"
+                            :caller-meta  caller-meta
+                            :times-to-try 1
+                            :sleep-time   probe/default-sleep-time}
                                 params)]
 
     (core/flow*
@@ -71,7 +73,7 @@
                                  (not (state/state? ~actual)))
                         (throw (ex-info "actual must be a step or a flow when :times-to-try > 1"
                                         {:times-to-try ~times-to-try
-                                         :actual ~actual}))))
+                                         :actual       ~actual}))))
        [flow-desc#  (core/current-description)
         fail-fast?# core/fail-fast?
         probe-res#  (#'match-probe (state/ensure-step ~actual) ~expected ~params*)

--- a/src/state_flow/assertions/matcher_combinators.clj
+++ b/src/state_flow/assertions/matcher_combinators.clj
@@ -52,9 +52,7 @@
    ;; deprecated cljtest/match? fn.  Undecided
    ;; whether we want to make it part of the API.
    ;; caller-meta is definitely not part of the API.
-  (let [f           *file*
-        a-ns        (str *ns*)
-        caller-meta (assoc (meta &form) :file f :ns a-ns)
+  (let [caller-meta (assoc (meta &form) :file *file* :ns (str *ns*))
         params*     (merge {:description  "match?"
                             :caller-meta  caller-meta
                             :times-to-try 1

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -36,7 +36,6 @@
    (fn [m] (-> m
                (update :top-level-description #(or % description))
                (update :description-stack (fnil conj [])
-                       ;; TODO: Add filename as well
                        (merge {:description description
                                :ns          ns}
                               (when line {:line line})

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -36,10 +36,10 @@
    (fn [m] (-> m
                (update :top-level-description #(or % description))
                (update :description-stack (fnil conj [])
-                       (merge {:description description
-                               :ns          ns}
-                              (when line {:line line})
-                              (when file {:file file})))))))
+                       (cond-> {:description description
+                                :ns ns}
+                         line (assoc :line line)
+                         file (assoc :file file)))))))
 
 (defn pop-meta
   "Returns a flow that will modify the state metadata.
@@ -129,13 +129,11 @@
   "Creates a flow which is a composite of flows."
   {:style/indent :defn}
   [description & flows]
-  (let [f    *file*
-        a-ns (str *ns*)]
-    (apply flow* {:description description
-                  :caller-meta (assoc (meta &form)
-                                      :file f
-                                      :ns a-ns)}
-           flows)))
+  (apply flow* {:description description
+                :caller-meta (assoc (meta &form)
+                                    :file *file*
+                                    :ns (str *ns*))}
+         flows))
 
 (defn top-level-description
   "Returns the description passed to the top level flow (or the

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -35,9 +35,10 @@
   (modify-meta
    (fn [m] (-> m
                (update :top-level-description #(or % description))
-               (update :description-stack (fnil conj []) (str description
-                                                              (when line
-                                                                (format " (line %s)" line))))))))
+               (update :description-stack (fnil conj [])
+                       ;; TODO: Add filename as well
+                       (merge {:description description}
+                              (when line {:line line})))))))
 
 (defn pop-meta
   "Returns a flow that will modify the state metadata.
@@ -46,9 +47,17 @@
   []
   (modify-meta update :description-stack pop))
 
+(defn ^:private format-single-description
+  [{:keys [line description]}]
+  (str description
+       (when line
+         (format " (line %s)" line))))
+
 (defn ^:private format-description
   [strs]
-  (str/join " -> " strs))
+  (->> strs
+       (map format-single-description)
+       (str/join " -> ")))
 
 (defn ^:private description-stack [s]
   (-> s meta :description-stack))

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -152,7 +152,7 @@
            (second (state-flow/run! (flow "just return initial state"))))))
 
   (testing "run! throws exception"
-    (is (thrown-with-msg? Exception #"root \(line \d+\) -> child2 \(line \d+\)"
+    (is (thrown-with-msg? Exception #"root \(core_test.clj:\d+\) -> child2 \(core_test.clj:\d+\)"
                           (test-helpers/run-flow bogus-flow {:value 0})))))
 
 (deftest as-step-fn
@@ -170,11 +170,11 @@
 
 (deftest current-description
   (testing "top level flow"
-    (is (re-matches #"level 1 \(line \d+\)"
+    (is (re-matches #"level 1 \(core_test.clj:\d+\)"
                     (first (state-flow/run (flow "level 1" (state-flow/current-description)))))))
 
   (testing "nested flows"
-    (is (re-matches #"level 1 \(line \d+\) -> level 2 \(line \d+\)"
+    (is (re-matches #"level 1 \(core_test.clj:\d+\) -> level 2 \(core_test.clj:\d+\)"
                     (first (state-flow/run (flow "level 1"
                                              (flow "level 2"
                                                (state-flow/current-description)))))))
@@ -187,13 +187,13 @@
                                    (flow "level 2"
                                      (flow "level 3"
                                        (state-flow/current-description)))))]
-      (is (re-matches #"level 1 \(line \d+\) -> level 2 \(line \d+\) -> level 3 \(line \d+\)" desc))
+      (is (re-matches #"level 1 \(core_test.clj:\d+\) -> level 2 \(core_test.clj:\d+\) -> level 3 \(core_test.clj:\d+\)" desc))
       (testing "line numbers are correct"
         (let [[level-1-line
                level-2-line
                level-3-line]
               (->> desc
-                   (re-find #"level 1 \(line (\d+)\) -> level 2 \(line (\d+)\) -> level 3 \(line (\d+)\)")
+                   (re-find #"level 1 \(core_test.clj:(\d+)\) -> level 2 \(core_test.clj:(\d+)\) -> level 3 \(core_test.clj:(\d+)\)")
                    (drop 1)
                    (map #(Integer/parseInt %)))]
           (is (consecutive? line-number-before-flow-invocation
@@ -207,14 +207,14 @@
           level-2  (flow "level 2" level-3)
           level-1  (flow "level 1" level-2)
           [desc _] (state-flow/run level-1)]
-      (is (re-matches #"level 1 \(line \d+\) -> level 2 \(line \d+\) -> level 3 \(line \d+\)"
+      (is (re-matches #"level 1 \(core_test.clj:\d+\) -> level 2 \(core_test.clj:\d+\) -> level 3 \(core_test.clj:\d+\)"
                       desc))
       (testing "line numbers are correct, even when composed"
         (let [[level-1-line
                level-2-line
                level-3-line]
               (->> desc
-                   (re-find #"level 1 \(line (\d+)\) -> level 2 \(line (\d+)\) -> level 3 \(line (\d+)\)")
+                   (re-find #"level 1 \(core_test.clj:(\d+)\) -> level 2 \(core_test.clj:(\d+)\) -> level 3 \(core_test.clj:(\d+)\)")
                    (drop 1)
                    (map #(Integer/parseInt %)))]
           (is (consecutive? line-number-before-flow-invocation
@@ -224,16 +224,16 @@
 
   (testing "after nested flows complete"
     (testing "within nested flows "
-      (is (re-matches #"level 1 \(line \d+\)"
+      (is (re-matches #"level 1 \(core_test.clj:\d+\)"
                       (first (state-flow/run (flow "level 1"
                                                (flow "level 2")
                                                (state-flow/current-description))))))
-      (is (re-matches #"level 1 \(line \d+\) -> level 2 \(line \d+\)"
+      (is (re-matches #"level 1 \(core_test.clj:\d+\) -> level 2 \(core_test.clj:\d+\)"
                       (first (state-flow/run (flow "level 1"
                                                (flow "level 2"
                                                  (flow "level 3")
                                                  (state-flow/current-description)))))))
-      (is (re-matches #"level 1 \(line \d+\)"
+      (is (re-matches #"level 1 \(core_test.clj:\d+\)"
                       (first (state-flow/run (flow "level 1"
                                                (flow "level 2"
                                                  (flow "level 3"))


### PR DESCRIPTION
- Add filename to flow descriptions. Use the following format: `<description> (<file>:<line>)`
- Put a map with flow metadata (line, file, etc) in state instead of directly putting the formatted string.
