### PR TITLE
fix `when` shadow warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [5.11.1]
+* fix `when` shadow warning
+
 ## [5.11.0]
 * add `when` to `state-flow.api`
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "5.11.0"
+(defproject nubank/state-flow "5.11.1"
   :description "Integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}

--- a/project.clj
+++ b/project.clj
@@ -21,7 +21,7 @@
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [com.taoensso/timbre "4.10.0"]
                  [funcool/cats "2.4.1"]
-                 [nubank/matcher-combinators "3.1.3"]]
+                 [nubank/matcher-combinators "3.1.4"]]
 
   :exclusions   [log4j]
 
@@ -33,7 +33,7 @@
   :profiles {:uberjar {:aot :all}
              :dev {:source-paths ["dev"]
                    :dependencies [[ns-tracker "0.4.0"]
-                                  [org.clojure/tools.namespace "1.0.0"]
+                                  [org.clojure/tools.namespace "1.1.0"]
                                   [midje "1.9.9"]
                                   [org.clojure/java.classpath "1.0.0"]
                                   [rewrite-clj "0.6.1"]]}}

--- a/src/state_flow/api.clj
+++ b/src/state_flow/api.clj
@@ -1,5 +1,5 @@
 (ns state-flow.api
-  (:refer-clojure :exclude [for])
+  (:refer-clojure :exclude [for when])
   (:require [cats.core :as m]
             [state-flow.assertions.matcher-combinators]
             [state-flow.cljtest]

--- a/src/state_flow/state.clj
+++ b/src/state_flow/state.clj
@@ -1,5 +1,5 @@
 (ns state-flow.state
-  (:refer-clojure :exclude [eval get])
+  (:refer-clojure :exclude [eval get when])
   (:require [cats.core :as m]
             [cats.monad.exception :as e]
             [cats.monad.state :as state]


### PR DESCRIPTION
follow up to https://github.com/nubank/state-flow/pull/147 to address
```
WARNING: when already refers to: #'clojure.core/when in namespace: state-flow.state, being repla
ced by: #'state-flow.state/when
WARNING: when already refers to: #'clojure.core/when in namespace: state-flow.api, being replace
d by: #'state-flow.api/when
```