### PR TITLE
Add clj-kondo hook to defflow

### DIFF
--- a/resources/clj-kondo.exports/nubank/state-flow/config.edn
+++ b/resources/clj-kondo.exports/nubank/state-flow/config.edn
@@ -1,2 +1,3 @@
 {:hooks {:analyze-call {state-flow.cljtest/defflow nubank.state-flow/defflow
-                        state-flow.core/flow       nubank.state-flow/flow}}}
+                        state-flow.core/flow       nubank.state-flow/flow
+                        state-flow.api/flow        nubank.state-flow/flow}}}

--- a/resources/clj-kondo.exports/nubank/state-flow/config.edn
+++ b/resources/clj-kondo.exports/nubank/state-flow/config.edn
@@ -1,0 +1,1 @@
+{:hooks {:analyze-call {state-flow.cljtest/defflow hooks.state-flow/defflow}}}

--- a/resources/clj-kondo.exports/nubank/state-flow/config.edn
+++ b/resources/clj-kondo.exports/nubank/state-flow/config.edn
@@ -1,1 +1,2 @@
-{:hooks {:analyze-call {state-flow.cljtest/defflow hooks.state-flow/defflow}}}
+{:hooks {:analyze-call {state-flow.cljtest/defflow nubank.state-flow/defflow
+                        state-flow.core/flow       nubank.state-flow/flow}}}

--- a/resources/clj-kondo.exports/nubank/state-flow/hooks/state_flow.clj
+++ b/resources/clj-kondo.exports/nubank/state-flow/hooks/state_flow.clj
@@ -1,0 +1,26 @@
+(ns hooks.state-flow
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn ^:private defflow-bindings [nodes]
+  (->> nodes
+       (filter api/vector-node?)
+       (map (fn [node]
+              (let [[sym val] (:children node)]
+                [sym val])))
+       flatten
+       vec))
+
+(defn ^:private defflow-flows [nodes]
+  (filter (complement api/vector-node?) nodes))
+
+(defn defflow [{:keys [:node]}]
+  (let [[name & flows] (rest (:children node))
+        new-node (api/list-node
+                  (list
+                   (with-meta (api/token-node 'defn) (meta name))
+                   (with-meta (api/token-node (api/sexpr name)) (meta name))
+                   (api/vector-node [])
+                   (api/list-node (list* (api/token-node 'let)
+                                         (api/vector-node (defflow-bindings flows))
+                                         (defflow-flows flows)))))]
+    {:node new-node}))

--- a/resources/clj-kondo.exports/nubank/state-flow/nubank/state_flow.clj
+++ b/resources/clj-kondo.exports/nubank/state-flow/nubank/state_flow.clj
@@ -1,4 +1,4 @@
-(ns hooks.state-flow
+(ns nubank.state-flow
   (:require [clj-kondo.hooks-api :as api]))
 
 (defn ^:private defflow-bindings [nodes]

--- a/resources/clj-kondo.exports/nubank/state-flow/nubank/state_flow.clj
+++ b/resources/clj-kondo.exports/nubank/state-flow/nubank/state_flow.clj
@@ -1,4 +1,4 @@
-(ns hooks.state-flow
+(ns nubank.state-flow
   (:require [clj-kondo.hooks-api :as hooks]))
 
 (defn- normalize-mlet-binds


### PR DESCRIPTION
The clj-kondo hook should tell to clj-kondo how to lint the custom macro `defflow`

Ref 1: https://github.com/clj-kondo/clj-kondo/blob/master/doc/config.md#exporting-and-importing-configuration
Ref 2: https://github.com/clj-kondo/clj-kondo/blob/master/doc/hooks.md#hooks

clj-kondo will find from the classpath the hook

With that we can just add ` :config-paths ["nubank/state-flow"]` to our clj-kondo home config and everything should work :)