### PR TITLE
Add clj-kondo defined-by to defflow hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [5.11.3]
+* Add `:defined-by` in `defflow` clj-kondo hook used by latest clj-kondo. This should fix clojure-lsp warnings about `unused-public-var` linter.
+
 ## [5.11.2]
 * Add clj-kondo hooks for `defflow` and `flow` to the classpath.
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "5.11.2"
+(defproject nubank/state-flow "5.11.3"
   :description "Integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}

--- a/resources/clj-kondo.exports/nubank/state-flow/nubank/state_flow.clj
+++ b/resources/clj-kondo.exports/nubank/state-flow/nubank/state_flow.clj
@@ -31,4 +31,5 @@
                   [(hooks/token-node 'def)
                    test-name
                    (do-let body)])]
-    {:node (with-meta new-node (meta node))}))
+    {:node (with-meta new-node (meta node))
+     :defined-by 'state-flow.cljtest/defflow}))


### PR DESCRIPTION
 Add `:defined-by` in `defflow` clj-kondo hook used by latest clj-kondo. This should fix clojure-lsp warnings about `unused-public-var` linter.
