### PR TITLE
Add description-stack to the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [5.12.0]
-* Make `state-flow.core/description-stack` public.
+* Label `state-flow.core/description-stack` as public (was only for internal usage).
 
 ## [5.11.3]
 * Add `:defined-by` in `defflow` clj-kondo hook used by latest clj-kondo. This should fix clojure-lsp warnings about `unused-public-var` linter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [5.12.0]
+* Make `state-flow.core/description-stack` public.
+
 ## [5.11.3]
 * Add `:defined-by` in `defflow` clj-kondo hook used by latest clj-kondo. This should fix clojure-lsp warnings about `unused-public-var` linter.
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "5.11.3"
+(defproject nubank/state-flow "5.12.0"
   :description "Integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}

--- a/src/state_flow/api.clj
+++ b/src/state_flow/api.clj
@@ -25,13 +25,14 @@
          when
          description-stack)
 
+;; The vars below represent the user API, that is,
+;; the set of public functions that one can use for writing flows.
 (import-vars
  state-flow.core/flow
  state-flow.core/run
  state-flow.core/run*
  state-flow.core/log-and-throw-error!
  state-flow.core/ignore-error
- state-flow.core/description-stack
 
  state-flow.state/invoke
  state-flow.state/return

--- a/src/state_flow/api.clj
+++ b/src/state_flow/api.clj
@@ -23,8 +23,7 @@
          match?
          get-state
          swap-state
-         when
-         description-stack)
+         when)
 
 (import-vars
  state-flow.core/flow

--- a/src/state_flow/api.clj
+++ b/src/state_flow/api.clj
@@ -1,4 +1,5 @@
 (ns state-flow.api
+  "This namespace provides the user API, that is, the set of public functions that one can use for writing flows."
   (:refer-clojure :exclude [for when])
   (:require [cats.core :as m]
             [state-flow.assertions.matcher-combinators]
@@ -25,8 +26,6 @@
          when
          description-stack)
 
-;; The vars below represent the user API, that is,
-;; the set of public functions that one can use for writing flows.
 (import-vars
  state-flow.core/flow
  state-flow.core/run

--- a/src/state_flow/api.clj
+++ b/src/state_flow/api.clj
@@ -22,7 +22,8 @@
          match?
          get-state
          swap-state
-         when)
+         when
+         description-stack)
 
 (import-vars
  state-flow.core/flow
@@ -30,6 +31,7 @@
  state-flow.core/run*
  state-flow.core/log-and-throw-error!
  state-flow.core/ignore-error
+ state-flow.core/description-stack
 
  state-flow.state/invoke
  state-flow.state/return

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -70,7 +70,14 @@
        (str/join " -> ")))
 
 (defn description-stack
-  "For internal use. Subject to change"
+  "Returns the list of descriptions in the current stack.
+
+  Example:
+  (description-stack s)
+  ;; =>
+  [{:description \"my test\"
+    :file \"my-test-file.clj\"
+    :line 42}]"
   [s]
   (-> s meta :description-stack))
 


### PR DESCRIPTION
This information is useful for extracting data from tests. This enables
us (for example) to generate visualizations with descriptions. See https://github.com/nubank/visual-flow/pull/36