### PR TITLE
recursively filter stack-traces + shorten other stack traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [5.13.0]
+* Recursively apply stack-trace filtering to exception causes
+* Shorten stack-trace raised by throw-error! to not include so much state-flow internals
+
 ## [5.12.0]
 * Label `state-flow.core/description-stack` as public (was only for internal usage).
 

--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,7 @@
             [changelog-check "0.1.0"]]
 
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [com.taoensso/timbre "4.10.0"]
+                 [com.taoensso/timbre "5.1.2"]
                  [funcool/cats "2.4.1"]
                  [nubank/matcher-combinators "3.1.4"]]
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "5.12.0"
+(defproject nubank/state-flow "5.13.0"
   :description "Integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -193,8 +193,11 @@
   "Error handler that throws the error."
   [pair]
   (let [description (state->current-description (second pair))
-        message     (str "Flow " "\"" description "\"" " failed with exception")]
-    (throw (ex-info message {} (m/extract (first pair))))))
+        message     (str "Flow " "\"" description "\"" " failed with exception")
+        exception   (ex-info message {} (m/extract (first pair)))]
+    (doto exception
+      (.setStackTrace (into-array (take 3 (into [] (.getStackTrace exception))))))
+    (throw exception)))
 
 (defn ^:deprecated log-and-throw-error!
   "DEPRECATED: Use (comp throw-error! log-error) instead. "

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -282,7 +282,7 @@
     `:on-error`         optional, function of the final result pair to be invoked when the first value in the pair represents an error, default:
                         `(comp throw-error!
                               log-error
-                              (filter-stack-trace default-strack-trace-exclusions))`"
+                              (filter-stack-trace default-stack-trace-exclusions))`"
   [{:keys [init cleanup runner on-error fail-fast? before-flow-hook]
     :or   {init                   (constantly {})
            cleanup                identity

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -228,7 +228,7 @@
 (defn deep-stack-trace-filter! [ex exclusions]
   (doto ex
     (.setStackTrace
-      (filter-stack-trace* exclusions (.getStackTrace ex))))
+     (filter-stack-trace* exclusions (.getStackTrace ex))))
   (when-let [cause (.getCause ex)]
     (recur cause exclusions)))
 
@@ -246,8 +246,8 @@
    (fn [pair]
      (if-let [failure (some->> pair first :failure)]
        (do (deep-stack-trace-filter! failure exclusions)
-         [(#'cats.monad.exception/->Failure failure)
-          (second pair)])
+           [(#'cats.monad.exception/->Failure failure)
+            (second pair)])
        pair))))
 
 (defn- unwrap-assertion-failure-value [pair]


### PR DESCRIPTION
If people like the changes I'll write tests for them

## recursively apply stack-trace filtering

### before

```
2021-04-22T18:04:45.468Z mboi-tui INFO [state-flow.core:8] - Flow "run-main-locally" failed with exception
    nrepl.middleware.interruptible-eval/evaluate/fn     interruptible_eval.clj:   87
                                                ...
                        clojure.core/with-bindings*                   core.clj: 1977 (repeats 2 times)
                                 clojure.core/apply                   core.clj:  667
                                                ...
 nrepl.middleware.interruptible-eval/evaluate/fn/fn     interruptible_eval.clj:   87
                                  clojure.core/eval                   core.clj: 3202
                                                ...
                              user$eval58135.invoke             NO_SOURCE_FILE:    1
                        user$eval58135.invokeStatic             NO_SOURCE_FILE:    1
                                                ...
                             clojure.test/run-tests                   test.clj:  768 (repeats 2 times)
                                 clojure.core/apply                   core.clj:  669
                                                ...
                                clojure.core/map/fn                   core.clj: 2759
                               clojure.test/test-ns                   test.clj:  758
                         clojure.test/test-all-vars                   test.clj:  737
                             clojure.test/test-vars                   test.clj:  731
                       clojure.test/default-fixture                   test.clj:  687
                          clojure.test/test-vars/fn                   test.clj:  735
                       clojure.test/default-fixture                   test.clj:  687
                       clojure.test/test-vars/fn/fn                   test.clj:  735
                              clojure.test/test-var                   test.clj:  717
                           clojure.test/test-var/fn                   test.clj:  717
               integration.apply-migrations-test/fn  apply_migrations_test.clj:  171
                               state-flow.core/run*                   core.clj:  299
                                state-flow.core/run                   core.clj:  265
                               cats.monad.state/run                 state.cljc:  147
           state-flow.state/error-catching-state/fn                  state.clj:   20
                                                ...
                       cats.monad.exception/wrap/fn             exception.cljc:  250
                   cats.monad.exception/exec-try-on             exception.cljc:  197
          cats.monad.exception/wrap/fn/func--auto--             exception.cljc:  250
                                 clojure.core/apply                   core.clj:  667
                                                ...
                          state-flow.state/reify/fn                  state.clj:   50
           state-flow.state/error-catching-state/fn                  state.clj:   20
                                                ...
                       cats.monad.exception/wrap/fn             exception.cljc:  250
                   cats.monad.exception/exec-try-on             exception.cljc:  197
          cats.monad.exception/wrap/fn/func--auto--             exception.cljc:  250
                                 clojure.core/apply                   core.clj:  667
                                                ...
                          state-flow.state/reify/fn                  state.clj:   50
                                  cats.core/bind/fn                  core.cljc:   96
         integration.apply-migrations-test/fn/fn/fn  apply_migrations_test.clj:  181
                                                ...
                             ordnungsamt.core/-main                   core.clj:  213
                             ordnungsamt.core/-main                   core.clj:  216
                      ordnungsamt.core/run-locally!                   core.clj:  211
                          ordnungsamt.core/run-run!                   core.clj:  197
                   ordnungsamt.core/run-migrations!                   core.clj:  171
                  ordnungsamt.core/run-migrations!*                   core.clj:  158
ordnungsamt.core/create-branch+run-base-migrations!                   core.clj:  140
                                clojure.core/reduce                   core.clj: 6830
                        clojure.core.protocols/fn/G              protocols.clj:   13
                          clojure.core.protocols/fn              protocols.clj:   75
                  clojure.core.protocols/seq-reduce              protocols.clj:   31
                        clojure.core.protocols/fn/G              protocols.clj:   19
                          clojure.core.protocols/fn              protocols.clj:  136
                                                ...
                            clojure.core/partial/fn                   core.clj: 2629
                    ordnungsamt.core/run-migration!                   core.clj:  131
           ordnungsamt.core/apply+commit-migration!                   core.clj:  114
                  ordnungsamt.core/apply-migration!                   core.clj:  105
                     ordnungsamt.core/drop-changes!                   core.clj:   73
                                                ...
                              clojure.java.shell/sh                  shell.clj:   79
                              clojure.java.shell/sh                  shell.clj:  113
                             java.lang.Runtime.exec               Runtime.java:  621
                     java.lang.ProcessBuilder.start        ProcessBuilder.java: 1029
                        java.lang.ProcessImpl.start           ProcessImpl.java:  134
                       java.lang.UNIXProcess.<init>           UNIXProcess.java:  247
                  java.lang.UNIXProcess.forkAndExec            UNIXProcess.java
java.io.IOException: error=2, No such file or directory
java.io.IOException: Cannot run program "git" (in directory "example-repo"): error=2, No such file or directory
```

### after

```
2021-04-22T18:04:20.368Z mboi-tui INFO [state-flow.core:8] - Flow "run-main-locally" failed with exception
                        clojure.core/with-bindings*                   core.clj: 1977 (repeats 2 times)
                                 clojure.core/apply                   core.clj:  667
                                  clojure.core/eval                   core.clj: 3202
                              user$eval57443.invoke             NO_SOURCE_FILE:    1
                        user$eval57443.invokeStatic             NO_SOURCE_FILE:    1
                             clojure.test/run-tests                   test.clj:  768 (repeats 2 times)
                                 clojure.core/apply                   core.clj:  669
                                clojure.core/map/fn                   core.clj: 2759
                               clojure.test/test-ns                   test.clj:  758
                         clojure.test/test-all-vars                   test.clj:  737
                             clojure.test/test-vars                   test.clj:  731
                       clojure.test/default-fixture                   test.clj:  687
                          clojure.test/test-vars/fn                   test.clj:  735
                       clojure.test/default-fixture                   test.clj:  687
                       clojure.test/test-vars/fn/fn                   test.clj:  735
                              clojure.test/test-var                   test.clj:  717
                           clojure.test/test-var/fn                   test.clj:  717
               integration.apply-migrations-test/fn  apply_migrations_test.clj:  171
                               state-flow.core/run*                   core.clj:  299
                                state-flow.core/run                   core.clj:  265
           state-flow.state/error-catching-state/fn                  state.clj:   20
                                 clojure.core/apply                   core.clj:  667
                          state-flow.state/reify/fn                  state.clj:   50
           state-flow.state/error-catching-state/fn                  state.clj:   20
                                 clojure.core/apply                   core.clj:  667
                          state-flow.state/reify/fn                  state.clj:   50
         integration.apply-migrations-test/fn/fn/fn  apply_migrations_test.clj:  181
                             ordnungsamt.core/-main                   core.clj:  213
                             ordnungsamt.core/-main                   core.clj:  216
                      ordnungsamt.core/run-locally!                   core.clj:  211
                          ordnungsamt.core/run-run!                   core.clj:  197
                   ordnungsamt.core/run-migrations!                   core.clj:  171
                  ordnungsamt.core/run-migrations!*                   core.clj:  158
ordnungsamt.core/create-branch+run-base-migrations!                   core.clj:  140
                                clojure.core/reduce                   core.clj: 6830
                        clojure.core.protocols/fn/G              protocols.clj:   13
                          clojure.core.protocols/fn              protocols.clj:   75
                  clojure.core.protocols/seq-reduce              protocols.clj:   31
                        clojure.core.protocols/fn/G              protocols.clj:   19
                          clojure.core.protocols/fn              protocols.clj:  136
                            clojure.core/partial/fn                   core.clj: 2629
                    ordnungsamt.core/run-migration!                   core.clj:  131
           ordnungsamt.core/apply+commit-migration!                   core.clj:  114
                  ordnungsamt.core/apply-migration!                   core.clj:  105
                     ordnungsamt.core/drop-changes!                   core.clj:   73
                              clojure.java.shell/sh                  shell.clj:   79
                              clojure.java.shell/sh                  shell.clj:  113
                             java.lang.Runtime.exec               Runtime.java:  621
                     java.lang.ProcessBuilder.start        ProcessBuilder.java: 1029
                        java.lang.ProcessImpl.start           ProcessImpl.java:  134
                       java.lang.UNIXProcess.<init>           UNIXProcess.java:  247
                  java.lang.UNIXProcess.forkAndExec            UNIXProcess.java
java.io.IOException: error=2, No such file or directory
java.io.IOException: Cannot run program "git" (in directory "example-repo"): error=2, No such file or directory
```

## shorten state-flow part of throw-error! stack-trace

### before

```
 at state_flow.core$throw_error_BANG_.invokeStatic (core.clj:197)
    state_flow.core$throw_error_BANG_.invoke (core.clj:192)
    clojure.core$comp$fn__5825.invoke (core.clj:2573)
    clojure.core$comp$fn__5825.invoke (core.clj:2573)
    state_flow.core$run_STAR_.invokeStatic (core.clj:307)
    state_flow.core$run_STAR_.invoke (core.clj:268)
    integration.apply_migrations_test$fn__46960.invokeStatic (apply_migrations_test.clj:171)
    integration.apply_migrations_test/fn (apply_migrations_test.clj:171)
    clojure.test$test_var$fn__9761.invoke (test.clj:717)
    clojure.test$test_var.invokeStatic (test.clj:717)
    clojure.test$test_var.invoke (test.clj:708)
    clojure.test$test_vars$fn__9787$fn__9792.invoke (test.clj:735)
    clojure.test$default_fixture.invokeStatic (test.clj:687)
    clojure.test$default_fixture.invoke (test.clj:683)
    clojure.test$test_vars$fn__9787.invoke (test.clj:735)
    clojure.test$default_fixture.invokeStatic (test.clj:687)
    clojure.test$default_fixture.invoke (test.clj:683)
    clojure.test$test_vars.invokeStatic (test.clj:731)
    clojure.test$test_all_vars.invokeStatic (test.clj:737)
    clojure.test$test_ns.invokeStatic (test.clj:758)
    clojure.test$test_ns.invoke (test.clj:743)
    clojure.core$map$fn__5884.invoke (core.clj:2759)
    clojure.lang.LazySeq.sval (LazySeq.java:42)
    clojure.lang.LazySeq.seq (LazySeq.java:51)
    clojure.lang.Cons.next (Cons.java:39)
    clojure.lang.RT.boundedLength (RT.java:1793)
    clojure.lang.RestFn.applyTo (RestFn.java:130)
    clojure.core$apply.invokeStatic (core.clj:669)
    clojure.test$run_tests.invokeStatic (test.clj:768)
    clojure.test$run_tests.doInvoke (test.clj:768)
    clojure.lang.RestFn.invoke (RestFn.java:408)
    state_flow.core$eval47067.invokeStatic (NO_SOURCE_FILE:1)
    state_flow.core$eval47067.invoke (NO_SOURCE_FILE:1)
    clojure.lang.Compiler.eval (Compiler.java:7181)
    clojure.lang.Compiler.eval (Compiler.java:7136)
    clojure.core$eval.invokeStatic (core.clj:3202)
    clojure.core$eval.invoke (core.clj:3198)
    nrepl.middleware.interruptible_eval$evaluate$fn__963$fn__964.invoke (interruptible_eval.clj
:87)
    clojure.lang.AFn.applyToHelper (AFn.java:152)
    clojure.lang.AFn.applyTo (AFn.java:144)
    clojure.core$apply.invokeStatic (core.clj:667)
    clojure.core$with_bindings_STAR_.invokeStatic (core.clj:1977)
    clojure.core$with_bindings_STAR_.doInvoke (core.clj:1977)
    clojure.lang.RestFn.invoke (RestFn.java:425)
    nrepl.middleware.interruptible_eval$evaluate$fn__963.invoke (interruptible_eval.clj:87)
    clojure.main$repl$read_eval_print__9110$fn__9113.invoke (main.clj:437)
    clojure.main$repl$read_eval_print__9110.invoke (main.clj:437)
    clojure.main$repl$fn__9119.invoke (main.clj:458)
    clojure.main$repl.invokeStatic (main.clj:458)
    clojure.main$repl.doInvoke (main.clj:368)
    clojure.lang.RestFn.invoke (RestFn.java:1523)
    nrepl.middleware.interruptible_eval$evaluate.invokeStatic (interruptible_eval.clj:84)
    nrepl.middleware.interruptible_eval$evaluate.invoke (interruptible_eval.clj:56)
    nrepl.middleware.interruptible_eval$interruptible_eval$fn__994$fn__998.invoke (interruptibl
e_eval.clj:152)
    clojure.lang.AFn.run (AFn.java:22)
    nrepl.middleware.session$session_exec$main_loop__1062$fn__1066.invoke (session.clj:202)
    nrepl.middleware.session$session_exec$main_loop__1062.invoke (session.clj:201)
    clojure.lang.AFn.run (AFn.java:22)
    java.lang.Thread.run (Thread.java:748)
Caused by: java.io.IOException: Cannot run program "git" (in directory "example-repo"): error=2
, No such file or directory
 at java.lang.ProcessBuilder.start (ProcessBuilder.java:1048)
    java.lang.Runtime.exec (Runtime.java:621)
    clojure.java.shell$sh.invokeStatic (shell.clj:113)
    clojure.java.shell$sh.doInvoke (shell.clj:79)
    ordnungsamt.core$drop_changes_BANG_.invokeStatic (core.clj:73)
...
another hundred lines
...
Caused by: java.io.IOException: error=2, No such file or directory
 at java.lang.UNIXProcess.forkAndExec (UNIXProcess.java:-2)
    java.lang.UNIXProcess.<init> (UNIXProcess.java:247)
    java.lang.ProcessImpl.start (ProcessImpl.java:134)
    java.lang.ProcessBuilder.start (ProcessBuilder.java:1029)
    java.lang.Runtime.exec (Runtime.java:621)
    clojure.java.shell$sh.invokeStatic (shell.clj:113)
...
another hundred lines
...
```

### after

```
ERROR in (run-main-locally) (NO_SOURCE_FILE:6)
Uncaught exception, not in assertion.
expected: nil
  actual: clojure.lang.ExceptionInfo: Flow "run-main-locally" failed with exception
{}
 at state_flow.core$throw_error_BANG_.invokeStatic (NO_SOURCE_FILE:6)
    state_flow.core$throw_error_BANG_.invoke (NO_SOURCE_FILE:1)
    clojure.core$comp$fn__5825.invoke (core.clj:2573)
Caused by: java.io.IOException: Cannot run program "git" (in directory "example-repo"): error=2
, No such file or directory
 at java.lang.ProcessBuilder.start (ProcessBuilder.java:1048)
    java.lang.Runtime.exec (Runtime.java:621)
    clojure.java.shell$sh.invokeStatic (shell.clj:113)
    clojure.java.shell$sh.doInvoke (shell.clj:79)
    ordnungsamt.core$drop_changes_BANG_.invokeStatic (core.clj:73)
...
another hundred lines
...
Caused by: java.io.IOException: error=2, No such file or directory
 at java.lang.UNIXProcess.forkAndExec (UNIXProcess.java:-2)
    java.lang.UNIXProcess.<init> (UNIXProcess.java:247)
    java.lang.ProcessImpl.start (ProcessImpl.java:134)
    java.lang.ProcessBuilder.start (ProcessBuilder.java:1029)
    java.lang.Runtime.exec (Runtime.java:621)
    clojure.java.shell$sh.invokeStatic (shell.clj:113)
...
another hundred lines
...
```