### PR TITLE
add flow information to test metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [5.14.0]
+- Add flow and parameters to test metadata on cljtest deflow
+
 ## [5.13.2]
 - Include line information when reporting flows that raise exceptions
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "5.13.4"
+(defproject nubank/state-flow "5.14.0"
   :description "Integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}

--- a/src/state_flow/cljtest.clj
+++ b/src/state_flow/cljtest.clj
@@ -49,9 +49,11 @@
   [name & forms]
   (let [[parameters & flows] (if (map? (first forms))
                                forms
-                               (cons {} forms))]
-    `(t/deftest ~name
-       (let [[ret# state#] (core/run* ~parameters (core/flow ~(str name) ~@flows))
+                               (cons {} forms))
+        flow `(core/flow ~(str name) ~@flows)]
+    `(t/deftest ~(vary-meta name assoc :state-flow {:flow flow
+                                                    :parameters parameters})
+       (let [[ret# state#] (core/run* ~parameters ~flow)
              assertions# (get-in (meta state#) [:test-report :assertions])]
          (doseq [assertion-data# assertions#]
            (t/report (#'clojure-test-report assertion-data#)))

--- a/src/state_flow/cljtest.clj
+++ b/src/state_flow/cljtest.clj
@@ -43,18 +43,18 @@
      :line (-> description-stack last :line)}))
 
 (defmacro defflow
-  {:doc "Creates a flow and binds it a Var named by name"
+  {:doc      "Creates a flow and binds it a Var named by name"
    :arglists '([name & flows]
                [name parameters & flows])}
   [name & forms]
   (let [[parameters & flows] (if (map? (first forms))
                                forms
                                (cons {} forms))
-        flow `(core/flow ~(str name) ~@flows)]
-    `(t/deftest ~(vary-meta name assoc :state-flow {:flow flow
+        flow                 `(core/flow ~(str name) ~@flows)]
+    `(t/deftest ~(vary-meta name assoc :state-flow {:flow       flow
                                                     :parameters parameters})
        (let [[ret# state#] (core/run* ~parameters ~flow)
-             assertions# (get-in (meta state#) [:test-report :assertions])]
+             assertions#   (get-in (meta state#) [:test-report :assertions])]
          (doseq [assertion-data# assertions#]
            (t/report (#'clojure-test-report assertion-data#)))
          [ret# state#]))))

--- a/test/state_flow/cljtest_test.clj
+++ b/test/state_flow/cljtest_test.clj
@@ -56,6 +56,15 @@
       (is (match? {:test 0 :pass 2 :fail 0 :error 0}
                   (merge-with - report-counters-after report-counters-before))))))
 
+(deftest get-flow-from-meta
+  (let [{{:keys [flow parameters]} :state-flow} (meta #'my-flow)]
+    (testing "We can grab the flow and parameters from test metadata"
+      (is (match? [{:match/result :match
+                    :match/actual {:a 1 :b 2}}
+                   {:value 1
+                    :map   {:a 1 :b 2}}]
+                  (state-flow/run* parameters flow))))))
+
 (deftest test-deprecated-match?
   (testing "with times-to-try > 1 and a value instead of a step"
     (testing "does not throw (to preserve backward compatibility)"


### PR DESCRIPTION
Adding flow and parameters to test metadata on defflow macro.
This is to facilitate usage of third party tools that may need to run the test flow with modified parameters.