### PR TITLE
Approach for avoid annotate-flows breaks factorio

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "5.14.0"
+(defproject nubank/state-flow "5.14.x"
   :description "Integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}


### PR DESCRIPTION
We tried add the conditional for to be able to create your own flow without annotate

in factorio was add this code

```
(defmacro flow
  "Creates a flow which is a composite of flows."
  {:style/indent :defn}
  [description & flows]
  (apply state-flow/flow* {:description description
                :annotate? false
                :caller-meta (assoc (meta &form)
                               :file *file*
                               :ns (str *ns*))}
         flows))
```