### PR TITLE
Fix state-flow pretty-printing for :actual in test result

### DIFF
--- a/test/state_flow/cljtest_test.clj
+++ b/test/state_flow/cljtest_test.clj
@@ -1,5 +1,6 @@
 (ns state-flow.cljtest-test
   (:require [clojure.test :as t :refer [deftest is testing]]
+            [matcher-combinators.result :as result]
             [matcher-combinators.test :refer [match?]]
             [state-flow.assertions.matcher-combinators :as mc]
             [state-flow.cljtest :refer [defflow] :as cljtest]
@@ -19,7 +20,8 @@
                 :flow/description-stack [{:description "my test"
                                           :file "my-test-file.clj"
                                           :line 23}]}
-        match-report (first (state-flow/run (mc/match? 1 2) {}))]
+        match-report (first (state-flow/run (mc/match? 1 2) {}))
+        report-with-details (assoc report :mismatch/detail 1)]
     (testing "we adapt state-flow assertion report into clojure-test report format"
       (is (match? {:type :fail
                    :message "my test (my-test-file.clj:23)"
@@ -29,8 +31,11 @@
                    :line 23}
                   (#'cljtest/clojure-test-report report))))
     (testing "we save pretty printing metadata"
-      (is (match? {:type :state-flow.cljtest/mismatch}
-                  (meta (:actual (#'cljtest/clojure-test-report match-report))))))))
+      (is (match? {:type :matcher-combinators.clj-test/mismatch}
+                  (meta (:actual (#'cljtest/clojure-test-report match-report))))))
+    (testing "is compatible with print-method of matcher-combinators"
+      (is (match? {:actual {:match-result {::result/value 1}}}
+                  (#'cljtest/clojure-test-report report-with-details))))))
 
 (deftest run-a-flow
   ;; NOTE:(sovelten,2020-12-15) This test works when called via clojure.test/run-tests


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/94179014/151843909-96ecb6d1-0421-433d-95e7-d7c2c3eb088e.png)

Due to a change in cider-nrepl ( https://github.com/clojure-emacs/cider-nrepl/commit/dff71aade8a8e73b0350f9ecb0f4a36cfb568d85 ), emacs cider wasn't printing the "actual" part of a matcher combinator result correctly. This can be seen on the right side of the screen shot. Cider includes `:summary ...` which shouldn't appear. The output as it should be can be seen on the left.


With this patch, we are using matcher-combinator's meta tag for mismatches. This way, cider-nrepl will use the dispatching print function and the "actual" section of the test result will be pretty-printed as usual.

Fixes https://nubank.atlassian.net/browse/DEV-471