### PR TITLE
Assoc init function to state metadata

### DIFF
--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -352,7 +352,8 @@
                                    assoc
                                    :runner runner
                                    :before-flow-hook before-flow-hook
-                                   :fail-fast? fail-fast?)
+                                   :fail-fast? fail-fast?
+                                   :init init)
         pair            (-> flow
                             (runner init-state+meta)
                             clarify-illegal-arg


### PR DESCRIPTION
I want to be able to run a slightly modified version of a flow from a fresh state, that's why I need to have access to the init function that was used.