### PR TITLE
Upgrade to Java 21 requirements

### DIFF
--- a/src/state_flow/probe.clj
+++ b/src/state_flow/probe.clj
@@ -19,7 +19,7 @@
 (defn ^:private with-delay
   "Adds a delay before the step is run"
   [step delay]
-  (m/>> (state/wrap-fn #(Thread/sleep delay)) step))
+  (m/>> (state/wrap-fn #(Thread/sleep ^long delay)) step))
 
 (defn ^:private sequence-while*
   "Like cats.core/sequence but with short circuiting when pred is satisfied by the return value of a step"

--- a/test/state_flow/test_helpers.clj
+++ b/test/state_flow/test_helpers.clj
@@ -20,7 +20,7 @@
   in `delay-ms` milliseconds."
   [delay-ms k f & args]
   (state/modify (fn [state]
-                  (future (do (Thread/sleep delay-ms)
+                  (future (do (Thread/sleep ^long delay-ms)
                               (apply swap! (get state k) f args)))
                   state)))
 


### PR DESCRIPTION
In Java 21, the Thread/sleep method has a new signature. Now, it's possible to send the sleep time using a long value or using a Duration object. It can cause errors when a service migrates to Java 21 depending the way the function is called.

To prevent this problem, we are creating this PR with the fix for this problem. It should continue work as expected in previous Java versions, but avoid problem when running in Java versions >= 19.

Please, merge this PR asap.

In case of doubt, please contact us at #systems-performance Slack channel.

Thanks!