### PR TITLE
Lint `state-flow.labs.state/with-redefs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 
+## [5.16.0]
+- Add linter for `state-flow.labs.state/with-redefs` [#175](https://github.com/nubank/state-flow/pull/175)
+
 ## [5.15.0]
 - Store init function in state metadata
 
 ## [5.14.5]
-- switch the declare/import-var function to def in state.api [#171](https://github.com/nubank/state-flow/pull/171) 
+- switch the declare/import-var function to def in state.api [#171](https://github.com/nubank/state-flow/pull/171)
 
 ## [5.14.4]
 - Bump midje to 1.10.9

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "5.15.0"
+(defproject nubank/state-flow "5.16.0"
   :description "Integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}

--- a/resources/clj-kondo.exports/nubank/state-flow/config.edn
+++ b/resources/clj-kondo.exports/nubank/state-flow/config.edn
@@ -1,5 +1,7 @@
 {:lint-as {state-flow.api/for clojure.core/for}
  :hooks   {:analyze-call {state-flow.cljtest/defflow nubank.state-flow/defflow
-                          state-flow.api/defflow     nubank.state-flow/defflow
-                          state-flow.core/flow       nubank.state-flow/flow
-                          state-flow.api/flow        nubank.state-flow/flow}}}
+                          state-flow.api/defflow nubank.state-flow/defflow
+                          state-flow.core/flow nubank.state-flow/flow
+                          state-flow.api/flow nubank.state-flow/flow
+                          state-flow.labs.state/with-redefs nubank.state-flow/with-redefs
+                          state-flow.vendor.potemkin/import-vars potemkin.namespaces/import-vars}}}

--- a/resources/clj-kondo.exports/nubank/state-flow/config.edn
+++ b/resources/clj-kondo.exports/nubank/state-flow/config.edn
@@ -1,7 +1,6 @@
 {:lint-as {state-flow.api/for clojure.core/for}
  :hooks   {:analyze-call {state-flow.cljtest/defflow nubank.state-flow/defflow
-                          state-flow.api/defflow nubank.state-flow/defflow
-                          state-flow.core/flow nubank.state-flow/flow
-                          state-flow.api/flow nubank.state-flow/flow
-                          state-flow.labs.state/with-redefs nubank.state-flow/with-redefs
-                          state-flow.vendor.potemkin/import-vars potemkin.namespaces/import-vars}}}
+                          state-flow.api/defflow     nubank.state-flow/defflow
+                          state-flow.core/flow       nubank.state-flow/flow
+                          state-flow.api/flow        nubank.state-flow/flow
+                          state-flow.labs.state/with-redefs nubank.state-flow/with-redefs}}}

--- a/resources/clj-kondo.exports/nubank/state-flow/nubank/state_flow.clj
+++ b/resources/clj-kondo.exports/nubank/state-flow/nubank/state_flow.clj
@@ -51,7 +51,7 @@
                   [(hooks/token-node 'clojure.core/with-redefs)
                    bindings
                    (hooks/list-node
-                    (concat [(hooks/token-node 'state-flow.core/flow)
+                    (concat [(hooks/token-node 'state-flow.api/flow)
                              (hooks/string-node "state-flow.labs.state/with-redefs")]
                             flows))])]
     {:node (with-meta new-node (meta node))

--- a/resources/clj-kondo.exports/nubank/state-flow/nubank/state_flow.clj
+++ b/resources/clj-kondo.exports/nubank/state-flow/nubank/state_flow.clj
@@ -55,7 +55,7 @@
                     [(hooks/token-node 'clojure.core/with-redefs)
                      bindings])
                    (hooks/list-node
-                    (concat [(hooks/token-node 'state-flow.core/flow)
+                    (concat [(hooks/token-node 'state-flow.api/flow)
                              (hooks/string-node "state-flow.labs.state/with-redefs")]
                             flows))])]
     {:node (with-meta new-node (meta node))

--- a/resources/clj-kondo.exports/nubank/state-flow/nubank/state_flow.clj
+++ b/resources/clj-kondo.exports/nubank/state-flow/nubank/state_flow.clj
@@ -22,12 +22,10 @@
      [(hooks/token-node 'let)
       (hooks/vector-node new-bindings)])))
 
-#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn flow [{:keys [node]}]
   (let [forms (rest (:children node))]
     {:node (with-meta (do-let forms) (meta node))}))
 
-#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn defflow [{:keys [node]}]
   (let [[test-name & body]     (rest (:children node))
         new-node (hooks/list-node
@@ -45,17 +43,15 @@
 
    into
 
-   (do (clojure.core/with-redefs bindings)
-       (state-flow.core/flow \"state-flow.labs.state/with-redefs\" flows))"
+   (clojure.core/with-redefs bindings
+     (state-flow.core/flow \"state-flow.labs.state/with-redefs\" flows))"
   [{:keys [node]}]
   (let [[bindings & flows] (rest (:children node))
         new-node (hooks/list-node
-                  [(hooks/token-node 'do)
+                  [(hooks/token-node 'clojure.core/with-redefs)
+                   bindings
                    (hooks/list-node
-                    [(hooks/token-node 'clojure.core/with-redefs)
-                     bindings])
-                   (hooks/list-node
-                    (concat [(hooks/token-node 'state-flow.api/flow)
+                    (concat [(hooks/token-node 'state-flow.core/flow)
                              (hooks/string-node "state-flow.labs.state/with-redefs")]
                             flows))])]
     {:node (with-meta new-node (meta node))


### PR DESCRIPTION
State-flow's let bindings weren't being linted when wrapped by a `state-flow.labs.state/with-redefs`.

This PR provides a transformation hook to teach `clj-kondo` how to analyze `state-flow.labs.state/with-redefs`.