### PR TITLE
Defflow in tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 StateFlow is a testing framework designed to support the composition and reuse of individual test steps.
 
+## Learning Materials
+- [Tutorial](./samples/tutorial.clj)
+- [Walkthrough](./doc/walkthrough.repl)
+
 ## Definitions
 
 * A [*flow*](#flows) is a sequence of steps or bindings.


### PR DESCRIPTION
The tutorial inside samples contains a 'Tests' section, where `state-flow.api/match?` is presented.

This PR adds examples featuring `state-flow.api/defflow` as well, since it can report mismatched assertions within flows, whereas `match?` will only return the result of the last evaluation.