### PR TITLE
Bump libraries 2024-12-31

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -21,6 +21,11 @@ jobs:
         distribution: 'temurin'
         java-version: ${{ matrix.java-version }}
 
+    - name: Install clojure tools
+      uses: DeLaGuardo/setup-clojure@13.0
+      with:
+        lein: 2.9.1
+
     - name: Print java version
       run: java -version
 

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install clojure tools
       uses: DeLaGuardo/setup-clojure@13.0
       with:
-        lein: 2.9.1
+        lein: 2.11.2
 
     - name: Print java version
       run: java -version
@@ -48,6 +48,11 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: 21
+
+    - name: Install clojure tools
+      uses: DeLaGuardo/setup-clojure@13.0
+      with:
+        lein: 2.11.2
 
     - name: Lint check
       run: lein lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,11 @@ jobs:
         distribution: 'temurin'
         java-version: ${{ matrix.java-version }}
 
+    - name: Install clojure tools
+      uses: DeLaGuardo/setup-clojure@13.0
+      with:
+        lein: 2.11.2
+
     - name: Print java version
       run: java -version
 
@@ -38,6 +43,16 @@ jobs:
     needs: test-using-java
     steps:
     - uses: actions/checkout@v4
+
+    - uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: 21
+
+    - name: Install clojure tools
+      uses: DeLaGuardo/setup-clojure@13.0
+      with:
+        lein: 2.11.2
 
     - name: Install dependencies
       run: lein deps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [5.19.0]
 - Bump dependencies
   - org.clojure/clojure from 1.11.4 to 1.12.0
-  - com.taoensso/timbe from 6.5.0 to 6.6.1
+  - com.taoensso/timbre from 6.5.0 to 6.6.1
   - rewrite-clj from 1.1.48 to 1.1.49
 
 ## [5.18.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [5.19.0]
+- Bump dependencies
+  - org.clojure/clojure from 1.11.4 to 1.12.0
+  - com.taoensso/timbe from 6.5.0 to 6.6.1
+  - rewrite-clj from 1.1.48 to 1.1.49
+
 ## [5.18.0]
 - Bump dependencies
   - org.clojure/clojure from 1.11.1 to 1.11.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 - Bump dependencies
   - org.clojure/clojure from 1.11.4 to 1.12.0
   - com.taoensso/timbre from 6.5.0 to 6.6.1
-  - rewrite-clj from 1.1.48 to 1.1.49
 
 ## [5.18.0]
 - Bump dependencies

--- a/project.clj
+++ b/project.clj
@@ -18,8 +18,8 @@
             [lein-nsorg "0.3.0"]
             [changelog-check "0.1.0"]]
 
-  :dependencies [[org.clojure/clojure "1.11.4"]
-                 [com.taoensso/timbre "6.5.0"]
+  :dependencies [[org.clojure/clojure "1.12.0"]
+                 [com.taoensso/timbre "6.6.1"]
                  [funcool/cats "2.4.2"]
                  [nubank/matcher-combinators "3.9.1"]]
 
@@ -36,7 +36,7 @@
                                   [org.clojure/tools.namespace "1.5.0"]
                                   [midje "1.10.10"]
                                   [org.clojure/java.classpath "1.1.0"]
-                                  [rewrite-clj "1.1.48"]]}}
+                                  [rewrite-clj "1.1.49"]]}}
 
   :aliases {"coverage" ["cloverage" "-s" "coverage"]
             "lint"     ["do" ["cljfmt" "check"] ["nsorg"]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "5.18.0"
+(defproject nubank/state-flow "5.19.0"
   :description "Integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}


### PR DESCRIPTION
Changelog:
- Bump org.clojure/clojure from 1.11.4 to 1.12.0
- Bump com.taoensso/timbre from 6.5.0 to 6.6.1