### PR TITLE
Remove timbre dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [5.20.0]
+- Remove `com.taoensso/timbre` dependency
+  - **BEHAVIOR CHANGE**: previously, failures logged by `state-flow.core/log-error` were sent to whatever 
+    appenders were configured in timbre. Now, failures are always logged to `clojure.core/*out*`.
+
 ## [5.19.0]
 - Bump dependencies
   - org.clojure/clojure from 1.11.4 to 1.12.0

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "5.19.0"
+(defproject nubank/state-flow "5.20.0"
   :description "Integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}
@@ -19,7 +19,7 @@
             [changelog-check "0.1.0"]]
 
   :dependencies [[org.clojure/clojure "1.12.0"]
-                 [com.taoensso/timbre "6.6.1"]
+                 [org.clj-commons/pretty "3.3.0"]
                  [funcool/cats "2.4.2"]
                  [nubank/matcher-combinators "3.9.1"]]
 

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -2,11 +2,11 @@
   (:refer-clojure :exclude [run!])
   (:require [cats.core :as m]
             [cats.monad.exception :as e]
+            [clj-commons.format.exceptions :as exceptions]
             [clojure.pprint :as pp]
             [clojure.string :as string]
             [state-flow.internals.description :as description]
-            [state-flow.state :as state]
-            [taoensso.timbre :as log]))
+            [state-flow.state :as state]))
 
 ;; From time to time we see the following error when trying to pretty-print
 ;; Failure records:
@@ -232,11 +232,12 @@
   pair)
 
 (defn log-error
-  "Error handler that logs error and returns pair."
+  "Error handler that logs error to clojure.core/*out* and returns pair."
   [pair]
-  (let [description (state->current-description (second pair))
+  (let [throwable   (m/extract (first pair))
+        description (state->current-description (second pair))
         message     (str "Flow " "\"" description "\"" " failed with exception")]
-    (log/info (m/extract (first pair)) message)
+    (println (str message "\n" (exceptions/format-exception throwable)))
     pair))
 
 (defn throw-error!


### PR DESCRIPTION
Always log failures to stdout, removing timbre (and some other transitive deps) as a dependency.

Printing to stdout is the default behavior for timbre, so for users that do not configure it explicitly no change is expected (other than a small format difference).

Exceptions are still printed using pretty, so the output for stack traces is exactly the same.

Output before:
```
2025-01-15T19:57:07.903Z marco.local INFO [state-flow.core:241] - Flow "root (core_test.clj:26) -> child2 (core_test.clj:28) -> bogus" failed with exception
             clojure.core/with-bindings*       core.clj: 1990 (repeats 2 times)
                                     ...
                       clojure.core/eval       core.clj: 3232
                          user/eval16619     REPL Input:
                  clojure.test/run-tests       test.clj:  768 (repeats 2 times)
                                     ...
java.lang.Exception: My exception
```

Output after:
```
Flow "root (core_test.clj:26) -> child2 (core_test.clj:28) -> bogus" failed with exception
             clojure.core/with-bindings*       core.clj: 1990 (repeats 2 times)
                                     ...
                       clojure.core/eval       core.clj: 3232
                          user/eval16619     REPL Input:
                  clojure.test/run-tests       test.clj:  768 (repeats 2 times)
                                     ...
java.lang.Exception: My exception
```

Classpath difference:
|                     :dep | :upstream | :head |
|--------------------------|-----------|-------|
|      com.taoensso/encore |   3.128.0 |       |
|      com.taoensso/timbre |     6.6.1 |       |
|       com.taoensso/truss |    1.12.0 |       |
| org.clojure/tools.reader |     1.5.0 |       |
|   org.clj-commons/pretty |     3.2.0 | 3.3.0 |