### PR TITLE
Use setMacro to flag macros in the api namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
+## [5.20.1]
+- Use setMacro to flag macros in the api namespace to avoid AOT compilation errors
+
 ## [5.20.0]
 - Remove `com.taoensso/timbre` dependency
-  - **BEHAVIOR CHANGE**: previously, failures logged by `state-flow.core/log-error` were sent to whatever 
+  - **BEHAVIOR CHANGE**: previously, failures logged by `state-flow.core/log-error` were sent to whatever
     appenders were configured in timbre. Now, failures are always logged to `clojure.core/*out*`.
 
 ## [5.19.0]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "5.20.0"
+(defproject nubank/state-flow "5.20.1"
   :description "Integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}

--- a/src/state_flow/api.clj
+++ b/src/state_flow/api.clj
@@ -8,10 +8,10 @@
             [state-flow.state]))
 
 (def ^{:doc      "Creates a flow which is a composite of flows."
-       :arglists '([description & flows])
-       :macro    true}
+       :arglists '([description & flows])}
   flow
   #'state-flow.core/flow)
+(.setMacro #'flow)
 
 (def ^{:arglists '([flow] [flow initial-state]),
        :doc      "Given an initial-state (default {}), runs a flow and returns a tuple of
@@ -92,10 +92,10 @@
   #'state-flow.state/when)
 
 (def ^{:arglists '([name & flows] [name parameters & flows]),
-       :doc      "Creates a flow and binds it a Var named by name",
-       :macro    true}
+       :doc      "Creates a flow and binds it a Var named by name"}
   defflow
   #'state-flow.cljtest/defflow)
+(.setMacro #'defflow)
 
 (def ^{:arglists '([expected actual & [{:keys [times-to-try sleep-time], :as params}]]),
        :doc      "Builds a state-flow step which uses matcher-combinators to make an
@@ -118,10 +118,10 @@
 
        Returns a map (in the left value) with information about the success
        or failure of the match, the details of which are used internally by
-       state-flow and subject to change.",
-       :macro    true}
+       state-flow and subject to change."}
   match?
   #'state-flow.assertions.matcher-combinators/match?)
+(.setMacro #'match?)
 
 (def ^{:arglists '([] [f & args]),
        :doc      "Creates a flow that returns the result of applying f (default identity)\nto state with any additional args."}


### PR DESCRIPTION
**Problem**

It is not possible to AOT-compile namespaces that use the defflow macro from the API namespace and get a faster development workflow as described [here](https://clojure.org/guides/dev_startup_time).

**Description**

Taking these namespaces as a starting point:

```clojure
(ns death-by-compilation-clj.my-defflow
  (:require [clojure.test :refer :all]))

(defmacro defflow
  [name]
  `(def ~name 1))
```
```clojure
(ns death-by-compilation-clj.my-dear-defflow
  (:require [clojure.test :refer :all]
            [death-by-compilation-clj.my-defflow :as my-defflow]))

(def ^{:macro    true}
  defflow #'my-defflow/defflow)
```
```clojure
(ns death-by-compilation-clj.my-dear-test
  (:require [clojure.test :refer :all]
            [death-by-compilation-clj.my-dear-defflow :refer [defflow]]))

(defflow my-dear-test-test)
```

When running `compile` on `death-by-compilation-clj.my-dear-test` it successfully compiles and writes to disk. Then if I kill the REPL, modify the file and repeat the process, the following error is thrown:

```
Syntax error compiling at (death_by_compilation_clj/my_dear_test.clj:7:1).
Unable to resolve symbol: my-dear-test-test in this context
```

**Solution**

By calling the setMacro method on the Vars that correspond to macros in the API namespace, we can flag them as the compiler expects and also add the macro metadata.

**References**

- https://clojurians-log.clojureverse.org/clojure/2023-01-18