### PR TITLE
Test new cats mlet macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [5.20.2]
+- Fixing the "Too long name" error when attempting to `compile` most namespaces that use `state-flow.` Details [here](https://github.com/funcool/cats/pull/247)
+
 ## [5.20.1]
 - Use setMacro to flag macros in the api namespace to avoid AOT compilation errors
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "5.20.1"
+(defproject nubank/state-flow "5.20.2-beta.1"
   :description "Integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}
@@ -20,7 +20,7 @@
 
   :dependencies [[org.clojure/clojure "1.12.0"]
                  [org.clj-commons/pretty "3.3.0"]
-                 [funcool/cats "2.4.2"]
+                 [funcool/cats "2.4.3-beta.1"]
                  [nubank/matcher-combinators "3.9.1"]]
 
   :exclusions   [log4j]


### PR DESCRIPTION
Fixing the "Too long name" error when attempting to `compile` most namespaces that use `state-flow.` Details [here](https://github.com/funcool/cats/pull/247).

Given the change is risky, this PR will come with a beta release.