### PR TITLE
Support missing destructuring scenarios in mlet for version 2.4.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/state-flow "5.20.2-beta.1"
+(defproject nubank/state-flow "5.20.2-beta.2"
   :description "Integration testing with composable flows"
   :url "https://github.com/nubank/state-flow"
   :license {:name "MIT"}
@@ -20,7 +20,7 @@
 
   :dependencies [[org.clojure/clojure "1.12.0"]
                  [org.clj-commons/pretty "3.3.0"]
-                 [funcool/cats "2.4.3-beta.1"]
+                 [funcool/cats "2.4.3-beta.2"]
                  [nubank/matcher-combinators "3.9.1"]]
 
   :exclusions   [log4j]


### PR DESCRIPTION
Details [here](https://github.com/funcool/cats/pull/248).