### PR TITLE
Allow `format` for a flow description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ pom.xml.asc
 *.iml
 .idea
 **/*.DS_Store
+.clj-kondo
+!.clj-kondo/config.edn

--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,7 @@
             [changelog-check "0.1.0"]]
 
   :dependencies [[org.clojure/clojure "1.12.0"]
-                 [org.clj-commons/pretty "3.3.0"]
+                 [org.clj-commons/pretty "3.5.0"]
                  [funcool/cats "2.4.3-beta.2"]
                  [nubank/matcher-combinators "3.9.1"]]
 

--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,7 @@
             [changelog-check "0.1.0"]]
 
   :dependencies [[org.clojure/clojure "1.11.3"]
-                 [com.taoensso/timbre "6.5.0"]
+                 [com.taoensso/timbre "6.7.1"]
                  [funcool/cats "2.4.2"]
                  [nubank/matcher-combinators "3.9.1"]]
 
@@ -32,11 +32,11 @@
 
   :profiles {:uberjar {:aot :all}
              :dev {:source-paths ["dev"]
-                   :dependencies [[ns-tracker "0.4.0"]
+                   :dependencies [[ns-tracker "1.0.0"]
                                   [org.clojure/tools.namespace "1.5.0"]
                                   [midje "1.10.10"]
                                   [org.clojure/java.classpath "1.1.0"]
-                                  [rewrite-clj "1.1.47"]]}}
+                                  [rewrite-clj "1.2.50"]]}}
 
   :aliases {"coverage" ["cloverage" "-s" "coverage"]
             "lint"     ["do" ["cljfmt" "check"] ["nsorg"]]

--- a/src/state_flow/core.clj
+++ b/src/state_flow/core.clj
@@ -107,8 +107,7 @@
 (defn- string-expr? [x]
   (or (string? x)
       (and (sequential? x)
-           (or (= (first x) 'str)
-               (= (first x) 'clojure.core/str)))))
+           (contains? #{'str `str 'format `format} (first x)))))
 
 (defn- state->current-description [s]
   (-> (description-stack s)

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -71,7 +71,7 @@
 
   (testing "flow with a `(format ..)` expr for the description is fine"
     (is (macroexpand `(flow (format "foo %s" "bar") [original (state/gets :value)
-                                         :let [doubled (* 2 original)]]
+                                                     :let [doubled (* 2 original)]]
                             (state/modify #(assoc % :value doubled))))))
 
   (testing "but flows with an expression that resolves to a string also aren't valid,

--- a/test/state_flow/core_test.clj
+++ b/test/state_flow/core_test.clj
@@ -69,6 +69,11 @@
                                          :let [doubled (* 2 original)]]
                             (state/modify #(assoc % :value doubled))))))
 
+  (testing "flow with a `(format ..)` expr for the description is fine"
+    (is (macroexpand `(flow (format "foo %s" "bar") [original (state/gets :value)
+                                         :let [doubled (* 2 original)]]
+                            (state/modify #(assoc % :value doubled))))))
+
   (testing "but flows with an expression that resolves to a string also aren't valid,
             due to resolution limitations at macro-expansion time"
     (is (re-find #"first argument .* must be .* description string"


### PR DESCRIPTION
Currently, just `str` (or `clojure.core/str`) are allowed, but `format` can be very useful as well.

Also bumped dependencies.